### PR TITLE
Charge report

### DIFF
--- a/protex/system.py
+++ b/protex/system.py
@@ -922,6 +922,7 @@ class IonicLiquidSystem:
         """
         pass
 
+    # TODO: Remove bc. deprecated in favor of ChargeReporter
     def report_charge_changes(self, filename: str, step: int, tot_steps: int) -> None:
         """
         call for each round, before first update to have step 0 as initial step saved
@@ -951,3 +952,66 @@ class IonicLiquidSystem:
                 f.write(
                     f'"{step}": {[residue.endstate_charge for residue in self.residues]}}}}}\n'
                 )
+
+
+class ChargeReporter:
+    """Charge Reporter reports the charges after an update intervals"""
+
+    def __init__(
+        self,
+        file: str,
+        reportInterval: int,
+        ionic_liquid: IonicLiquidSystem,
+        append: bool = False,
+        header_data: dict = None,
+    ):
+        # allow for a header line with information
+        self._openedFile = isinstance(file, str)
+        if self._openedFile:
+            self._out = open(file, "a" if append else "w")
+        else:
+            self._out = file
+        self._hasInitialized = False
+        self.header_data = header_data
+        self.ionic_liquid = ionic_liquid
+        self._reportInterval = reportInterval
+
+    def describeNextReport(self, simulation):
+        """Get information about the next report this object will generate.
+        Parameters
+        ----------
+        simulation : Simulation
+            The Simulation to generate a report for
+        Returns
+        -------
+        tuple
+            A five element tuple. The first element is the number of steps
+            until the next report. The remaining elements specify whether
+            that report will require positions, velocities, forces, and
+            energies respectively.
+        """
+        steps = self._reportInterval - simulation.currentStep % self._reportInterval
+        return (steps, False, False, False, False)
+
+    def report(self, simulation, state):
+        if not self._hasInitialized:
+            self._hasInitialized = True
+            if isinstance(self.header_data, dict):
+                print(
+                    ", ".join(
+                        [f"{key}: {value}" for key, value in self.header_data.items()]
+                    ),
+                    file=self._out,
+                )
+            print("Step\tCharges", file=self._out)
+
+        print(
+            f"{self.ionic_liquid.simulation.currentStep}\t{[residue.endstate_charge for residue in self.ionic_liquid.residues]}",
+            file=self._out,
+        )
+
+        if hasattr(self._out, "flush") and callable(self._out.flush):
+            self._out.flush()
+
+    def __del__(self):
+        self._out.close()

--- a/protex/system.py
+++ b/protex/system.py
@@ -922,37 +922,6 @@ class IonicLiquidSystem:
         """
         pass
 
-    # TODO: Remove bc. deprecated in favor of ChargeReporter
-    def report_charge_changes(self, filename: str, step: int, tot_steps: int) -> None:
-        """
-        call for each round, before first update to have step 0 as initial step saved
-        report_charge_changes reports the current charges after each update step in a dictionary format:
-        {"step": [residue_charges]}
-        additional header data is the dcd save frequency needed for later reconstruction of the charges at different steps
-        Parameters:
-        filename: str
-        step: int, current update step
-        tot_step: int, number of total update steps
-        """
-        # TODO: use json module or something similar, right now not very usefull with this tot_step thing to match the brackets
-        if step == 0:
-            mode = "w"
-        else:
-            mode = "a"
-
-        with open(filename, mode) as f:
-            if mode == "w":
-                f.write('{"dcd_save_freq": 100,\n')  # TODO: fetch automatically!
-                f.write('"charges_at_step": {\n')
-            if step != tot_steps - 1:
-                f.write(
-                    f'"{step}": {[residue.endstate_charge for residue in self.residues]},\n'
-                )
-            elif step == tot_steps - 1:
-                f.write(
-                    f'"{step}": {[residue.endstate_charge for residue in self.residues]}}}}}\n'
-                )
-
 
 class ChargeReporter:
     """Charge Reporter reports the charges after an update intervals

--- a/protex/system.py
+++ b/protex/system.py
@@ -955,7 +955,20 @@ class IonicLiquidSystem:
 
 
 class ChargeReporter:
-    """Charge Reporter reports the charges after an update intervals"""
+    """Charge Reporter reports the charges after an update intervals
+    Used to reoprt the charge for each molecule in the system.
+    Ideally call in conjunction with an update and report just when charge changed.
+    i.e.
+    ChargeReporter(file, 10)
+    simulation.step(9)
+    state_update.update(2)
+    simulation.step(8)
+    state_update.update(2)
+    simulation.step(8)
+    simulation.step(1)
+    then the reporter is invoked directyl in the update, after the one step with the previous charge, but before any charge changes take effect.
+
+    """
 
     def __init__(
         self,

--- a/protex/tests/test_system.py
+++ b/protex/tests/test_system.py
@@ -744,7 +744,7 @@ def test_reporter_class():
     state_update = StateUpdate(update)
 
     report_interval = 5
-    charge_info = {"dcd_save_freq": 500, "hallo": {"hh": 4}, "1": [1, 2, 3, 4]}
+    charge_info = {"dcd_save_freq": 500}
     charge_reporter = ChargeReporter(stdout, 20, ionic_liquid, header_data=charge_info)
     ionic_liquid.simulation.reporters.append(charge_reporter)
     ionic_liquid.simulation.reporters.append(

--- a/protex/tests/test_system.py
+++ b/protex/tests/test_system.py
@@ -727,6 +727,10 @@ def test_report_charge_changes():
     assert len(data["charges_at_step"]["1"]) == 1000
 
 
+@pytest.mark.skipif(
+    os.getenv("CI") == "true",
+    reason="Skipping tests that cannot pass in github actions",
+)
 def test_reporter_class():
     # obtain simulation object
     simulation = generate_im1h_oac_system()


### PR DESCRIPTION
## Description
Adding a ChargeReporter Class. Used to report the charges of all molecules in the simulation
Invoked like any other OpenMM reporters with simulation.reporters.append(ChargeReporter(file, step))

## Todos
  - [x] Implement ChargeReporter Class
  - [x] Write test case
  - [x] remove old report_charge_changes function from IonicLiquidSystem

## Status
- [x] Ready to go