### PR TITLE
added parameter to NaiceMCUpdate to specify which forces to update

### DIFF
--- a/protex/system.py
+++ b/protex/system.py
@@ -120,7 +120,7 @@ class Residue:
         if force_name == "NonbondedForce":
             parms = self._get_NonbondedForce_parameters_at_lambda(lamb)
             self._set_NonbondedForce_parameters(parms)
-        elif force_name == "HarmonicBondedForce":
+        elif force_name == "HarmonicBondForce":
             parms = self._get_HarmonicBondForce_parameters_at_lambda(lamb)
             self._set_HarmonicBondForce_parameters(parms)
         elif force_name == "HarmonicAngleForce":

--- a/protex/tests/test_update.py
+++ b/protex/tests/test_update.py
@@ -1317,3 +1317,33 @@ def test_single_im1h_oac():
                 if ["IM1H", "OAC", "IM1", "HOAC"] == list(exceptions_after.keys()):
                     break
     assert sorted(exceptions_before) == sorted(exceptions_after)
+
+
+def test_force_selection():
+    simulation = generate_im1h_oac_system()
+    allowed_updates = {}
+    # allowed updates according to simple protonation scheme
+    allowed_updates[frozenset(["IM1H", "OAC"])] = {
+        "r_max": 0.16,
+        "delta_e": 2.33,
+    }  # r_max in nanometer, delta_e in kcal/mol
+    allowed_updates[frozenset(["IM1", "HOAC"])] = {"r_max": 0.16, "delta_e": -2.33}
+    # allowed_updates[frozenset(["IM1H", "IM1"])] = {"r_max": 0.16, "delta_e": 1.78}
+    # allowed_updates[frozenset(["HOAC", "OAC"])] = {"r_max": 0.16, "delta_e": 0.68}
+    # get ionic liquid templates
+    templates = IonicLiquidTemplates([OAC_HOAC, IM1H_IM1], (allowed_updates))
+    # wrap system in IonicLiquidSystem
+    ionic_liquid = IonicLiquidSystem(simulation, templates)
+    update = NaiveMCUpdate(ionic_liquid)
+    assert update.allowed_forces == ["NonbondedForce", "DrudeForce"]
+    update = NaiveMCUpdate(ionic_liquid, all_forces=False)
+    assert update.allowed_forces == ["NonbondedForce", "DrudeForce"]
+    update = NaiveMCUpdate(ionic_liquid, all_forces=True)
+    assert update.allowed_forces == [
+        "NonbondedForce",
+        "DrudeForce",
+        "HarmonicBondForce",
+        "HarmonicAngleForce",
+        "PeriodicTorsionForce",
+        "CustomTorsionForce",
+    ]

--- a/protex/update.py
+++ b/protex/update.py
@@ -30,16 +30,23 @@ class NaiveMCUpdate(Update):
         [description]
     """
 
-    def __init__(self, ionic_liquid: IonicLiquidSystem) -> None:
+    def __init__(
+        self, ionic_liquid: IonicLiquidSystem, all_forces: bool = False
+    ) -> None:
         super().__init__(ionic_liquid)
-        self.allowed_forces = [
+        self.allowed_forces = [  # change charges only
             "NonbondedForce",  # BUG: Charge stored in the DrudeForce does NOT get updated, probably you want to allow DrudeForce as well!
-            # "HarmonicBondedForce",
-            # "HarmonicAngleForce",
-            # "PeriodicTorsionForce",
-            # "CustomTorsionForce",
             "DrudeForce",
         ]
+        if all_forces:
+            self.allowed_forces.extend(
+                [
+                    "HarmonicBondForce",
+                    "HarmonicAngleForce",
+                    "PeriodicTorsionForce",
+                    "CustomTorsionForce",
+                ]
+            )
 
     def _update(self, candidates: List[Tuple], nr_of_steps: int):
         logger.info("called _update")
@@ -179,7 +186,9 @@ class StateUpdate:
 
         if len(candidate_pairs) == 0:
             print("No transfers this time")
-            self.ionic_liquid.simulation.step(nr_of_steps) # also do the simulation steps if no update occurs, to be consistent in simulation time
+            self.ionic_liquid.simulation.step(
+                nr_of_steps
+            )  # also do the simulation steps if no update occurs, to be consistent in simulation time
         elif len(candidate_pairs) > 0:
             self.updateMethod._update(candidate_pairs, nr_of_steps)
 


### PR DESCRIPTION
## Description
Idea is to easily switch between only updating the charges during a Trasnfer event or also all Bonded Forces

## Todos
  - [x] Add parameter to NaiveMCUpdate Constructor to allow for selection of forces to update
  - [x] Add test case

## Status
- [x] Ready to go