### PR TITLE
added psf writing functionality, wrapper for saving/loading state/checkpoint

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -11,6 +11,7 @@ dependencies:
   - openmm
   - scipy
   - numpy
+  - parmed
 
     # Testing
   - pytest

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -19,6 +19,7 @@ dependencies:
   - codecov
 
     # Pip-only installs
-  #- pip:
+  - pip:
   #  - codecov
+    - git+https://github.com/ParmEd/ParmEd.git
 

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -8,7 +8,7 @@ dependencies:
     # Base depends
   - python
   - pip
-  - openmm
+  - openmm=7.6
   - scipy
   - numpy
   - parmed


### PR DESCRIPTION
## Description
Add functionality to write psf files after a transfer occured. Main usage for reading restart files and also a updated psf.
Wrapper for the Simulation Object functions saveState, loadState, saveCheckpoint and loadCheckpoint in IonicLiquid Class

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] write_psf function
  - [x] tests

## Status
- [x] Ready to go