### PR TITLE
meoh2

### DIFF
--- a/protex/residue.py
+++ b/protex/residue.py
@@ -57,6 +57,7 @@ class Residue:
         alternativ_parameters,
         # canonical_name,
         pair_12_13_exclusion_list,
+        has_equivalent_atom,
     ) -> None:
 
         self.residue = residue
@@ -73,6 +74,9 @@ class Residue:
         self.system = system
         self.record_charge_state.append(self.endstate_charge)  # Not used anywhere?
         self.pair_12_13_list = pair_12_13_exclusion_list
+        self.has_equivalent_atom: bool = has_equivalent_atom
+        self.equivalent_atom_pos_in_list: int = None
+        self.used_equivalent_atom: bool = False
 
     @property
     def alternativ_name(self):

--- a/protex/system.py
+++ b/protex/system.py
@@ -496,7 +496,7 @@ class ProtexSystem:
                         parameters_state2,
                         # self.templates.get_canonical_name(name),
                         pair_12_13_list,
-                        self.templates.has_equivalent_atom(name)
+                        self.templates.has_equivalent_atom(name),
                     )
                 )
                 residues[

--- a/protex/system.py
+++ b/protex/system.py
@@ -77,6 +77,18 @@ class ProtexTemplates:
         self.overall_max_distance: float = max(
             [value["r_max"] for value in self.allowed_updates.values()]
         )
+        # store names in variables, in case syntax for states dict changes
+        self._atom_name: str = "atom_name"
+        self._equivalent_atom: str = "equivalent_atom"
+
+    def get_atom_name_for(self, resname: str) -> str:
+        return self.states[resname][self._atom_name]
+
+    def has_equivalent_atom(self, resname: str) -> bool:
+        return self._equivalent_atom in self.states[resname]
+
+    def get_equivalent_atom_for(self, resname: str) -> str:
+        return self.states[resname][self._equivalent_atom]
 
     def get_update_value_for(self, residue_set: frozenset[str], property: str) -> float:
         """
@@ -484,6 +496,7 @@ class ProtexSystem:
                         parameters_state2,
                         # self.templates.get_canonical_name(name),
                         pair_12_13_list,
+                        self.templates.has_equivalent_atom(name)
                     )
                 )
                 residues[

--- a/protex/system.py
+++ b/protex/system.py
@@ -12,7 +12,7 @@ import yaml
 try:
     import openmm
 except ImportError:
-    import simtk.openmm
+    import simtk.openmm as openmm
 
 from protex.residue import Residue
 

--- a/protex/tests/test_hpts.py
+++ b/protex/tests/test_hpts.py
@@ -1117,7 +1117,11 @@ def test_reporter_class():
     ionic_liquid.simulation.reporters.append(charge_reporter)
     ionic_liquid.simulation.reporters.append(
         StateDataReporter(
-            stdout, report_interval, step=True, time=True, totalEnergy=True,
+            stdout,
+            report_interval,
+            step=True,
+            time=True,
+            totalEnergy=True,
         )
     )
 
@@ -1132,7 +1136,8 @@ def test_reporter_class():
 
 
 @pytest.mark.skipif(
-    os.getenv("CI") == "true", reason="Will fail sporadicaly.",
+    os.getenv("CI") == "true",
+    reason="Will fail sporadicaly.",
 )
 def test_write_psf_save_load():
     psf_for_parameters = f"{protex.__path__[0]}/forcefield/psf_for_parameters.psf"
@@ -1194,7 +1199,8 @@ def test_write_psf_save_load():
 
 
 @pytest.mark.skipif(
-    os.getenv("CI") == "true", reason="Will fail sporadicaly.",
+    os.getenv("CI") == "true",
+    reason="Will fail sporadicaly.",
 )
 def test_updates(caplog):
     caplog.set_level(logging.DEBUG)
@@ -1253,7 +1259,8 @@ def test_updates(caplog):
 
 
 @pytest.mark.skipif(
-    os.getenv("CI") == "true", reason="Will fail sporadicaly.",
+    os.getenv("CI") == "true",
+    reason="Will fail sporadicaly.",
 )
 def test_pbc():
 
@@ -1326,7 +1333,8 @@ def test_pbc():
 
 
 @pytest.mark.skipif(
-    os.getenv("CI") == "true", reason="Will fail sporadicaly.",
+    os.getenv("CI") == "true",
+    reason="Will fail sporadicaly.",
 )
 def test_residue_forces():
     psf_for_parameters = f"{protex.__path__[0]}/forcefield/psf_for_parameters.psf"
@@ -1798,7 +1806,8 @@ def test_count_forces():
 
 
 @pytest.mark.skipif(
-    os.getenv("CI") == "true", reason="Will fail sporadicaly.",
+    os.getenv("CI") == "true",
+    reason="Will fail sporadicaly.",
 )
 def test_update_write_psf():
     psf_for_parameters = f"{protex.__path__[0]}/forcefield/psf_for_parameters.psf"

--- a/protex/testsystems.py
+++ b/protex/testsystems.py
@@ -1294,6 +1294,7 @@ MEOH_MEOH2 = {
     },
     "MEOH2": {
         "atom_name": "HO2",
+        "other_h": "HO1",
         "canonical_name": "MEOH",
     },
 }

--- a/protex/testsystems.py
+++ b/protex/testsystems.py
@@ -1290,11 +1290,9 @@ HPTSH_HPTS = {
 MEOH_MEOH2 = {
     "MEOH": {
         "atom_name": "O1",
-        "canonical_name": "MEOH",
     },
     "MEOH2": {
         "atom_name": "HO2",
-        "other_h": "HO1",
-        "canonical_name": "MEOH",
+        "equivalent_atom": "HO1",
     },
 }

--- a/protex/update.py
+++ b/protex/update.py
@@ -74,10 +74,12 @@ class NaiveMCUpdate(Update):
         # TODO:
         for candidate in candidates:
             candidate1_residue, candidate2_residue = sorted(
-                    candidate, key=lambda candidate: candidate.current_name
-                )
+                candidate, key=lambda candidate: candidate.current_name
+            )
             if candidate1_residue.used_equivalent_atom:
-                candidate1_residue.used_equivalent_atom = False # reset for next update round
+                candidate1_residue.used_equivalent_atom = (
+                    False  # reset for next update round
+                )
                 self._reorient_atoms()
             if candidate2_residue.used_equivalent_atom:
                 candidate2_residue.used_equivalent_atom = False
@@ -384,7 +386,9 @@ class StateUpdate:
                     proposed_candidate_pair = (residue1, residue2)
                     # reject if already used in this transfer call
                     # print(f"{residue1=}, {residue2=}")
-                    if residue1 in used_residues or residue2 in used_residues: #TODO: is this working with changing some variables in the classes?
+                    if (
+                        residue1 in used_residues or residue2 in used_residues
+                    ):  # TODO: is this working with changing some variables in the classes?
                         logger.debug(
                             f"{residue1.current_name}:{residue1.residue.id}:{charge_candidate_idx1}-{residue2.current_name}:{residue2.residue.id}:{charge_candidate_idx2} pair rejected, bc used this transfer call ..."
                         )
@@ -398,7 +402,9 @@ class StateUpdate:
                         continue
                     # accept otherwise
                     proposed_candidate_pairs.append(proposed_candidate_pair)
-                    if candidate_idx1 == residue1.equivalent_atom_pos_in_list: # check if we used the actual atom or onyl the equivalent
+                    if (
+                        candidate_idx1 == residue1.equivalent_atom_pos_in_list
+                    ):  # check if we used the actual atom or onyl the equivalent
                         residue1.used_equivalent_atom = True
                     if candidate_idx2 == residue2.equivalent_atom_pos_in_list:
                         residue2.used_equivalent_atom = True
@@ -435,7 +441,9 @@ class StateUpdate:
             pos_list.append(
                 pos[
                     residue.get_idx_for_atom_name(
-                        self.ionic_liquid.templates.get_atom_name_for(residue.current_name)
+                        self.ionic_liquid.templates.get_atom_name_for(
+                            residue.current_name
+                        )
                     )
                     # this needs the atom idx to be the same for both topologies
                     # TODO: maybe get rid of this caveat
@@ -448,11 +456,15 @@ class StateUpdate:
                 pos_list.append(
                     pos[
                         residue.get_idx_for_atom_name(
-                            self.ionic_liquid.templates.get_equivalent_atom_for(residue.current_name)
+                            self.ionic_liquid.templates.get_equivalent_atom_for(
+                                residue.current_name
+                            )
                         )
                     ]
                 )
-                residue.equivalent_atom_pos_in_list = len(res_list) # store idx to know which coordinates where used for distance
+                residue.equivalent_atom_pos_in_list = len(
+                    res_list
+                )  # store idx to know which coordinates where used for distance
                 res_list.append(
                     residue
                 )  # add second time the residue to have same length of pos_list and res_list

--- a/protex/update.py
+++ b/protex/update.py
@@ -21,7 +21,11 @@ class Update:
         Needs the IonicLiquidSystem
     """
 
-    def __init__(self, ionic_liquid: ProtexSystem, to_adapt=None,) -> None:
+    def __init__(
+        self,
+        ionic_liquid: ProtexSystem,
+        to_adapt=None,
+    ) -> None:
         self.ionic_liquid: ProtexSystem = ionic_liquid
         self.to_adapt: list[tuple[str, int, frozenset[str]]] = to_adapt
 


### PR DESCRIPTION
## Description
Idea: include a second hydrogen on i.e. oxygen for the consideration of possible transfers.
first approach to include second hydrogen in distance calculation for meoh2
## Todos
  - [ ] **Testing!**, is it even doing what we want?
  - [ ] Better integrate this poor man's approach! (Current version just to get it running for this specific case)

## Status
- [ ] Ready to go

---

Die Supersäure gibt ihr Proton an ein Methanol ab. Dieses protonierte Methanol hat dann zwei Wasserstoffe am Sauerstoff, die eigentlich für das Proton hopping gleichberechtigt sein sollten. In der jetzigen Programmversion haben wir bisher aber immer nur die Möglichkeit in Betracht gezogen, dass nur das Wasserstoff wieder abgegeben werden kann, das aus einem Dummy entstanden ist. Dies ist eigentlich auch nicht im Sinne des Grotthus-Mechanismus. Wir haben nun die Idee geboren, dass bei einem Protonentransfer-Event nicht nur die Abstände dieses Wasserstoffes zu potentiellen Akzeptoren überprüft wird, sondern auch der andere Wasserstoff zu seinen entsprechenden potentiellen Akzeptoren.

Beim Transfer wird natürlich wieder nur der Wasserstoff in ein Dummy überführt, der vorher auch ein Dummy war. Eigentlich müsste man in diesem Fall 180° um die OH-Bindung drehen, damit es wieder richtig stimmt, aber dies sollten wir zunächst einmal vernachlässigen. 

---