### PR TITLE
Update refactor

### DIFF
--- a/protex/residue.py
+++ b/protex/residue.py
@@ -23,6 +23,8 @@ class Residue:
         A general name for both states (protonated/deprotonated)
     pair_12_13_exclusion_list: list
         1-2 and 1-3 exclusions in the system
+    equivalent_atoms: tuple
+        if current name and alternative name have equivalent atoms
 
     Attributes
     -----------
@@ -57,7 +59,8 @@ class Residue:
         alternativ_parameters,
         # canonical_name,
         pair_12_13_exclusion_list,
-        has_equivalent_atom,
+        # has_equivalent_atom,
+        equivalent_atoms,
     ) -> None:
 
         self.residue = residue
@@ -74,9 +77,18 @@ class Residue:
         self.system = system
         self.record_charge_state.append(self.endstate_charge)  # Not used anywhere?
         self.pair_12_13_list = pair_12_13_exclusion_list
-        self.has_equivalent_atom: bool = has_equivalent_atom
+        #self.has_equivalent_atom: bool = has_equivalent_atom
+        self.equivalent_atoms: dict[str,bool] = {self.original_name: equivalent_atoms[0], self.alternativ_name: equivalent_atoms[1]}
         self.equivalent_atom_pos_in_list: int = None
         self.used_equivalent_atom: bool = False
+
+    @property
+    def has_equivalent_atom(self):
+        """
+        Determines if the current residue has an equivalent atom defined.
+        It depends i.e if the residue is currently OAC (-> two equivalent O's) or HOAC (no equivlent O's).
+        """
+        return self.equivalent_atoms[self.current_name]
 
     @property
     def alternativ_name(self):

--- a/protex/residue.py
+++ b/protex/residue.py
@@ -77,8 +77,11 @@ class Residue:
         self.system = system
         self.record_charge_state.append(self.endstate_charge)  # Not used anywhere?
         self.pair_12_13_list = pair_12_13_exclusion_list
-        #self.has_equivalent_atom: bool = has_equivalent_atom
-        self.equivalent_atoms: dict[str,bool] = {self.original_name: equivalent_atoms[0], self.alternativ_name: equivalent_atoms[1]}
+        # self.has_equivalent_atom: bool = has_equivalent_atom
+        self.equivalent_atoms: dict[str, bool] = {
+            self.original_name: equivalent_atoms[0],
+            self.alternativ_name: equivalent_atoms[1],
+        }
         self.equivalent_atom_pos_in_list: int = None
         self.used_equivalent_atom: bool = False
 

--- a/protex/residue.py
+++ b/protex/residue.py
@@ -57,6 +57,7 @@ class Residue:
         alternativ_parameters,
         # canonical_name,
         pair_12_13_exclusion_list,
+        has_equivalent_atom,
     ) -> None:
 
         self.residue = residue
@@ -73,6 +74,9 @@ class Residue:
         self.system = system
         self.record_charge_state.append(self.endstate_charge)  # Not used anywhere?
         self.pair_12_13_list = pair_12_13_exclusion_list
+        self.has_equivalent_atom: bool = has_equivalent_atom
+        self.equivalent_atom_pos_in_list: int = None
+        self.used_equivalent_atom: bool = False
 
     @property
     def alternativ_name(self):

--- a/protex/residue.py
+++ b/protex/residue.py
@@ -48,6 +48,8 @@ class Residue:
         The system generated with openMM, where all residues are in
     pair_12_13_list: list
          1-2 and 1-3 exclusions in the system
+    has_equivalent_atoms: tuple(bool)
+        if orignal_name and alternative name have equivalent atoms
     """
 
     def __init__(
@@ -60,7 +62,7 @@ class Residue:
         # canonical_name,
         pair_12_13_exclusion_list,
         # has_equivalent_atom,
-        equivalent_atoms,
+        has_equivalent_atoms,
     ) -> None:
 
         self.residue = residue
@@ -79,8 +81,8 @@ class Residue:
         self.pair_12_13_list = pair_12_13_exclusion_list
         # self.has_equivalent_atom: bool = has_equivalent_atom
         self.equivalent_atoms: dict[str, bool] = {
-            self.original_name: equivalent_atoms[0],
-            self.alternativ_name: equivalent_atoms[1],
+            self.original_name: has_equivalent_atoms[0],
+            self.alternativ_name: has_equivalent_atoms[1],
         }
         self.equivalent_atom_pos_in_list: int = None
         self.used_equivalent_atom: bool = False

--- a/protex/system.py
+++ b/protex/system.py
@@ -496,7 +496,7 @@ class ProtexSystem:
                         parameters_state2,
                         # self.templates.get_canonical_name(name),
                         pair_12_13_list,
-                        self.templates.has_equivalent_atom(name),
+                        (self.templates.has_equivalent_atom(name),self.templates.has_equivalent_atom(name_of_paired_ion)),
                     )
                 )
                 residues[

--- a/protex/system.py
+++ b/protex/system.py
@@ -496,7 +496,7 @@ class ProtexSystem:
                         parameters_state2,
                         # self.templates.get_canonical_name(name),
                         pair_12_13_list,
-                        self.templates.has_equivalent_atom(name)
+                        self.templates.has_equivalent_atom(name),
                     )
                 )
                 residues[

--- a/protex/system.py
+++ b/protex/system.py
@@ -77,6 +77,18 @@ class ProtexTemplates:
         self.overall_max_distance: float = max(
             [value["r_max"] for value in self.allowed_updates.values()]
         )
+        # store names in variables, in case syntax for states dict changes
+        self._atom_name: str = "atom_name"
+        self._equivalent_atom: str = "equivalent_atom"
+
+    def get_atom_name_for(self, resname: str) -> str:
+        return self.states[resname][self._atom_name]
+
+    def has_equivalent_atom(self, resname: str) -> bool:
+        return self._equivalent_atom in self.states[resname]
+
+    def get_equivalent_atom_for(self, resname: str) -> str:
+        return self.states[resname][self._equivalent_atom]
 
     def get_update_value_for(self, residue_set: frozenset[str], property: str) -> float:
         """
@@ -484,6 +496,7 @@ class ProtexSystem:
                         parameters_state2,
                         # self.templates.get_canonical_name(name),
                         pair_12_13_list,
+                        self.templates.has_equivalent_atom(name)
                     )
                 )
                 residues[

--- a/protex/system.py
+++ b/protex/system.py
@@ -12,7 +12,7 @@ import yaml
 try:
     import openmm
 except ImportError:
-    import simtk.openmm
+    import simtk.openmm as openmm
 
 from protex.residue import Residue
 

--- a/protex/system.py
+++ b/protex/system.py
@@ -258,8 +258,8 @@ class ProtexSystem:
         self.templates: ProtexTemplates = templates
         self.simulation_for_parameters = simulation_for_parameters
         self.residues: list[Residue] = self._set_initial_states()
-        self.boxlength: float = (
-            simulation.context.getState().getPeriodicBoxVectors()[0][0]._value
+        self.boxlength: openmm.Quantity = (
+            simulation.context.getState().getPeriodicBoxVectors()[0][0]
         )  # NOTE: supports only cubic boxes
 
     def get_current_number_of_each_residue_type(self) -> dict[str, int]:

--- a/protex/system.py
+++ b/protex/system.py
@@ -496,7 +496,10 @@ class ProtexSystem:
                         parameters_state2,
                         # self.templates.get_canonical_name(name),
                         pair_12_13_list,
-                        (self.templates.has_equivalent_atom(name),self.templates.has_equivalent_atom(name_of_paired_ion)),
+                        (
+                            self.templates.has_equivalent_atom(name),
+                            self.templates.has_equivalent_atom(name_of_paired_ion),
+                        ),
                     )
                 )
                 residues[

--- a/protex/tests/test_hpts.py
+++ b/protex/tests/test_hpts.py
@@ -2033,45 +2033,4 @@ def test_updates_with_reorient():
     os.remove("hpts_new.psf")
 
 
-@pytest.mark.skipif(
-    os.getenv("CI") == "true",
-    reason="Will fail sporadicaly.",
-)
-def test_manipulating_coordinates():
-    psf_for_parameters = f"{protex.__path__[0]}/forcefield/psf_for_parameters.psf"
-    crd_for_parameters = f"{protex.__path__[0]}/forcefield/crd_for_parameters.crd"
-    psf_file = f"{protex.__path__[0]}/forcefield/hpts.psf"
-    restart_file = f"{protex.__path__[0]}/forcefield/traj/hpts_npt_7.rst"
-
-    simulation = generate_hpts_meoh_system(psf_file=psf_file, restart_file=restart_file)
-    simulation_for_parameters = generate_hpts_meoh_system(
-        psf_file=psf_for_parameters, crd_file=crd_for_parameters
-    )
-    allowed_updates = {}
-    allowed_updates[frozenset(["IM1H", "OAC"])] = {"r_max": 0.16, "prob": 1}
-    allowed_updates[frozenset(["IM1", "HOAC"])] = {"r_max": 0.16, "prob": 1}
-    allowed_updates[frozenset(["IM1H", "IM1"])] = {"r_max": 0.16, "prob": 0.201}  # 1+2
-    allowed_updates[frozenset(["HOAC", "OAC"])] = {"r_max": 0.15, "prob": 0.684}  # 3+4
-    allowed_updates[frozenset(["HPTSH", "OAC"])] = {"r_max": 0.15, "prob": 1.000}
-    allowed_updates[frozenset(["HPTSH", "IM1"])] = {"r_max": 0.15, "prob": 1.000}
-    allowed_updates[frozenset(["HPTSH", "MEOH"])] = {"r_max": 0.155, "prob": 1.000}
-    allowed_updates[frozenset(["MEOH2", "MEOH"])] = {"r_max": 0.155, "prob": 1.000}
-    allowed_updates[frozenset(["MEOH2", "IM1"])] = {"r_max": 0.155, "prob": 1.000}
-    allowed_updates[frozenset(["MEOH2", "OAC"])] = {"r_max": 0.155, "prob": 1.000}
-
-    templates = ProtexTemplates(
-        [OAC_HOAC, IM1H_IM1, HPTSH_HPTS, MEOH_MEOH2], (allowed_updates)
-    )
-    # wrap system in IonicLiquidSystem
-    ionic_liquid = ProtexSystem(simulation, templates, simulation_for_parameters)
-
-    positions = ionic_liquid.simulation.context.getState(
-        getPositions=True
-    ).getPositions(asNumpy=True)
-
-    a = positions[0]
-    print(a)
-    b = positions[1]
-    print(b)
-    c = a - 0.9 * (a - b)
-    print(c)
+ 

--- a/protex/tests/test_hpts.py
+++ b/protex/tests/test_hpts.py
@@ -1328,7 +1328,7 @@ def test_pbc():
     # print(f"{distance_pbc[0]=}")
     # print(f"{distance_pbc[distance_pbc>boxl]=}")
     assert (
-        len(distance_pbc[distance_pbc > boxl]) == 0
+        len(distance_pbc[distance_pbc > boxl.value_in_unit(nanometers)]) == 0
     ), "After correcting for PBC no distance should be larger than the boxlength"
 
 

--- a/protex/tests/test_hpts.py
+++ b/protex/tests/test_hpts.py
@@ -2031,6 +2031,3 @@ def test_updates_with_reorient():
     ionic_liquid.write_psf(old_psf_file, "hpts_new.psf", psf_for_parameters)
 
     os.remove("hpts_new.psf")
-
-
- 

--- a/protex/tests/test_hpts.py
+++ b/protex/tests/test_hpts.py
@@ -2060,7 +2060,7 @@ def test_manipulating_coordinates():
     )
     # wrap system in IonicLiquidSystem
     ionic_liquid = ProtexSystem(simulation, templates, simulation_for_parameters)
-    boxl=ionic_liquid.boxlength
+    boxl = ionic_liquid.boxlength
 
     positions = ionic_liquid.simulation.context.getState(
         getPositions=True
@@ -2070,10 +2070,10 @@ def test_manipulating_coordinates():
     x1 = positions_copy[0]
     x2 = positions_copy[10]
 
-    print(f'{x1=}, {x2=}')
+    print(f"{x1=}, {x2=}")
     positions[0] = x2
-    positions[10]= x1
+    positions[10] = x1
 
     ionic_liquid.simulation.context.setPositions(positions)
 
-    print(f'{positions[0]=}, {positions[10]=}')
+    print(f"{positions[0]=}, {positions[10]=}")

--- a/protex/tests/test_hpts.py
+++ b/protex/tests/test_hpts.py
@@ -2032,6 +2032,7 @@ def test_updates_with_reorient():
 
     os.remove("hpts_new.psf")
 
+
 @pytest.mark.skipif(
     os.getenv("CI") == "true",
     reason="Will fail sporadicaly.",
@@ -2064,14 +2065,13 @@ def test_manipulating_coordinates():
     # wrap system in IonicLiquidSystem
     ionic_liquid = ProtexSystem(simulation, templates, simulation_for_parameters)
 
-    positions =  ionic_liquid.simulation.context.getState(
-            getPositions=True
-        ).getPositions(asNumpy=True)
+    positions = ionic_liquid.simulation.context.getState(
+        getPositions=True
+    ).getPositions(asNumpy=True)
 
     a = positions[0]
     print(a)
     b = positions[1]
     print(b)
-    c = a-0.9*(a-b)
+    c = a - 0.9 * (a - b)
     print(c)
-    

--- a/protex/tests/test_hpts.py
+++ b/protex/tests/test_hpts.py
@@ -1258,7 +1258,6 @@ def test_updates(caplog):
     os.remove("hpts_new.psf")
 
 
-
 @pytest.mark.skipif(
     os.getenv("CI") == "true",
     reason="Will fail sporadicaly.",
@@ -1973,12 +1972,13 @@ def test_meoh2_update():
     # os.remove("checkpoint.rst")
     # os.remove("test.psf")
 
+
 @pytest.mark.skipif(
     os.getenv("CI") == "true",
     reason="Will fail sporadicaly.",
 )
 def test_updates_with_reorient():
-   # caplog.set_level(logging.DEBUG)
+    # caplog.set_level(logging.DEBUG)
 
     psf_for_parameters = f"{protex.__path__[0]}/forcefield/psf_for_parameters.psf"
     crd_for_parameters = f"{protex.__path__[0]}/forcefield/crd_for_parameters.crd"
@@ -2013,7 +2013,7 @@ def test_updates_with_reorient():
     # wrap system in IonicLiquidSystem
     ionic_liquid = ProtexSystem(simulation, templates, simulation_for_parameters)
     pars = []
-    update = NaiveMCUpdate(ionic_liquid, meoh2 = True)
+    update = NaiveMCUpdate(ionic_liquid, meoh2=True)
     # initialize state update class
     state_update = StateUpdate(update)
     # ionic_liquid.simulation.minimizeEnergy(maxIterations=200)
@@ -2031,4 +2031,3 @@ def test_updates_with_reorient():
     ionic_liquid.write_psf(old_psf_file, "hpts_new.psf", psf_for_parameters)
 
     os.remove("hpts_new.psf")
-

--- a/protex/tests/test_hpts.py
+++ b/protex/tests/test_hpts.py
@@ -2031,3 +2031,47 @@ def test_updates_with_reorient():
     ionic_liquid.write_psf(old_psf_file, "hpts_new.psf", psf_for_parameters)
 
     os.remove("hpts_new.psf")
+
+@pytest.mark.skipif(
+    os.getenv("CI") == "true",
+    reason="Will fail sporadicaly.",
+)
+def test_manipulating_coordinates():
+    psf_for_parameters = f"{protex.__path__[0]}/forcefield/psf_for_parameters.psf"
+    crd_for_parameters = f"{protex.__path__[0]}/forcefield/crd_for_parameters.crd"
+    psf_file = f"{protex.__path__[0]}/forcefield/hpts.psf"
+    restart_file = f"{protex.__path__[0]}/forcefield/traj/hpts_npt_7.rst"
+
+    simulation = generate_hpts_meoh_system(psf_file=psf_file, restart_file=restart_file)
+    simulation_for_parameters = generate_hpts_meoh_system(
+        psf_file=psf_for_parameters, crd_file=crd_for_parameters
+    )
+    allowed_updates = {}
+    allowed_updates[frozenset(["IM1H", "OAC"])] = {"r_max": 0.16, "prob": 1}
+    allowed_updates[frozenset(["IM1", "HOAC"])] = {"r_max": 0.16, "prob": 1}
+    allowed_updates[frozenset(["IM1H", "IM1"])] = {"r_max": 0.16, "prob": 0.201}  # 1+2
+    allowed_updates[frozenset(["HOAC", "OAC"])] = {"r_max": 0.15, "prob": 0.684}  # 3+4
+    allowed_updates[frozenset(["HPTSH", "OAC"])] = {"r_max": 0.15, "prob": 1.000}
+    allowed_updates[frozenset(["HPTSH", "IM1"])] = {"r_max": 0.15, "prob": 1.000}
+    allowed_updates[frozenset(["HPTSH", "MEOH"])] = {"r_max": 0.155, "prob": 1.000}
+    allowed_updates[frozenset(["MEOH2", "MEOH"])] = {"r_max": 0.155, "prob": 1.000}
+    allowed_updates[frozenset(["MEOH2", "IM1"])] = {"r_max": 0.155, "prob": 1.000}
+    allowed_updates[frozenset(["MEOH2", "OAC"])] = {"r_max": 0.155, "prob": 1.000}
+
+    templates = ProtexTemplates(
+        [OAC_HOAC, IM1H_IM1, HPTSH_HPTS, MEOH_MEOH2], (allowed_updates)
+    )
+    # wrap system in IonicLiquidSystem
+    ionic_liquid = ProtexSystem(simulation, templates, simulation_for_parameters)
+
+    positions =  ionic_liquid.simulation.context.getState(
+            getPositions=True
+        ).getPositions(asNumpy=True)
+
+    a = positions[0]
+    print(a)
+    b = positions[1]
+    print(b)
+    c = a-0.9*(a-b)
+    print(c)
+    

--- a/protex/tests/test_hpts.py
+++ b/protex/tests/test_hpts.py
@@ -65,7 +65,7 @@ from ..testsystems import (  # generate_single_hpts_system,
     OAC_HOAC,
     generate_hpts_meoh_system,
 )
-from ..update import NaiveMCUpdate, StateUpdate
+from ..update import KeepHUpdate, NaiveMCUpdate, StateUpdate
 
 ############################
 # TEST SYSTEM
@@ -1923,16 +1923,17 @@ def test_meoh2_update():
     # wrap system in IonicLiquidSystem
     ionic_liquid = ProtexSystem(simulation, templates, simulation_for_parameters)
     # initialize update method
-    update = NaiveMCUpdate(ionic_liquid, meoh2=True)
+    # update = NaiveMCUpdate(ionic_liquid, meoh2=True)
+    update = KeepHUpdate(ionic_liquid, include_equivalent_atom=True, reorient=True)
     # initialize state update class
     state_update = StateUpdate(update)
 
     # old_psf_file = f"{protex.__path__[0]}/forcefield/hpts.psf"
     # ionic_liquid.write_psf(old_psf_file, "test.psf", psf_for_parameters)
 
-    print(state_update.updateMethod.meoh2)
+    # print(state_update.updateMethod.meoh2)
     print("Finished")
-    assert False
+    # assert False
 
     # state_update.update(2)
 

--- a/protex/tests/test_hpts.py
+++ b/protex/tests/test_hpts.py
@@ -33,7 +33,7 @@ try:  # Syntax changed in OpenMM 7.6
         Simulation,
         StateDataReporter,
     )
-    from openmm.unit import angstroms, kelvin, picoseconds
+    from openmm.unit import angstroms, kelvin, nanometers, picoseconds
 except ImportError:
     import simtk.openmm as mm
     from simtk.openmm import (
@@ -48,7 +48,7 @@ except ImportError:
     from simtk.openmm.app import CharmmCrdFile, CharmmParameterSet, CharmmPsfFile
     from simtk.openmm.app import PME, HBonds
     from simtk.openmm.app import Simulation
-    from simtk.unit import angstroms, kelvin, picoseconds
+    from simtk.unit import angstroms, kelvin, picoseconds, nanometers
 
 import pytest
 from scipy.spatial import distance_matrix
@@ -1312,7 +1312,7 @@ def test_pbc():
 
     from scipy.spatial.distance import cdist
 
-    def _rPBC(coor1, coor2, boxl=boxl):
+    def _rPBC(coor1, coor2, boxl=ionic_liquid.boxlength.value_in_unit(nanometers)):
         dx = abs(coor1[0] - coor2[0])
         if dx > boxl / 2:
             dx = boxl - dx
@@ -2014,7 +2014,8 @@ def test_updates_with_reorient():
     # wrap system in IonicLiquidSystem
     ionic_liquid = ProtexSystem(simulation, templates, simulation_for_parameters)
     pars = []
-    update = NaiveMCUpdate(ionic_liquid, meoh2=True)
+    # update = NaiveMCUpdate(ionic_liquid, meoh2=True)
+    update = KeepHUpdate(ionic_liquid, include_equivalent_atom=True, reorient=True)
     # initialize state update class
     state_update = StateUpdate(update)
     # ionic_liquid.simulation.minimizeEnergy(maxIterations=200)
@@ -2061,7 +2062,6 @@ def test_manipulating_coordinates():
     )
     # wrap system in IonicLiquidSystem
     ionic_liquid = ProtexSystem(simulation, templates, simulation_for_parameters)
-    boxl = ionic_liquid.boxlength
 
     positions = ionic_liquid.simulation.context.getState(
         getPositions=True

--- a/protex/tests/test_hpts.py
+++ b/protex/tests/test_hpts.py
@@ -1117,7 +1117,11 @@ def test_reporter_class():
     ionic_liquid.simulation.reporters.append(charge_reporter)
     ionic_liquid.simulation.reporters.append(
         StateDataReporter(
-            stdout, report_interval, step=True, time=True, totalEnergy=True,
+            stdout,
+            report_interval,
+            step=True,
+            time=True,
+            totalEnergy=True,
         )
     )
 
@@ -1132,7 +1136,8 @@ def test_reporter_class():
 
 
 @pytest.mark.skipif(
-    os.getenv("CI") == "true", reason="Will fail sporadicaly.",
+    os.getenv("CI") == "true",
+    reason="Will fail sporadicaly.",
 )
 def test_write_psf_save_load():
     psf_for_parameters = f"{protex.__path__[0]}/forcefield/psf_for_parameters.psf"
@@ -1194,7 +1199,8 @@ def test_write_psf_save_load():
 
 
 @pytest.mark.skipif(
-    os.getenv("CI") == "true", reason="Will fail sporadicaly.",
+    os.getenv("CI") == "true",
+    reason="Will fail sporadicaly.",
 )
 def test_updates(caplog):
     caplog.set_level(logging.DEBUG)
@@ -1253,7 +1259,8 @@ def test_updates(caplog):
 
 
 @pytest.mark.skipif(
-    os.getenv("CI") == "true", reason="Will fail sporadicaly.",
+    os.getenv("CI") == "true",
+    reason="Will fail sporadicaly.",
 )
 def test_pbc():
 
@@ -1326,7 +1333,8 @@ def test_pbc():
 
 
 @pytest.mark.skipif(
-    os.getenv("CI") == "true", reason="Will fail sporadicaly.",
+    os.getenv("CI") == "true",
+    reason="Will fail sporadicaly.",
 )
 def test_residue_forces():
     psf_for_parameters = f"{protex.__path__[0]}/forcefield/psf_for_parameters.psf"
@@ -1798,7 +1806,8 @@ def test_count_forces():
 
 
 @pytest.mark.skipif(
-    os.getenv("CI") == "true", reason="Will fail sporadicaly.",
+    os.getenv("CI") == "true",
+    reason="Will fail sporadicaly.",
 )
 def test_update_write_psf():
     psf_for_parameters = f"{protex.__path__[0]}/forcefield/psf_for_parameters.psf"

--- a/protex/tests/test_system.py
+++ b/protex/tests/test_system.py
@@ -1013,17 +1013,17 @@ def test_write_psf_save_load_clap():
     state_update = StateUpdate(update)
 
     old_psf_file = psf
-    ionic_liquid.write_psf(old_psf_file, "testc1.psf")
+    ionic_liquid.write_psf(old_psf_file, "test1c.psf")
 
     # ionic_liquid.simulation.step(50)
     state_update.update(2)
 
-    ionic_liquid.write_psf(old_psf_file, "testc2.psf")
+    ionic_liquid.write_psf(old_psf_file, "test2c.psf")
 
     ionic_liquid.simulation.step(10)
     state_update.update(2)
 
-    ionic_liquid.write_psf(old_psf_file, "testc3.psf")
+    ionic_liquid.write_psf(old_psf_file, "test3c.psf")
 
     ionic_liquid.saveState("statec.rst")
     ionic_liquid.saveCheckpoint("checkpointc.rst")

--- a/protex/tests/test_system.py
+++ b/protex/tests/test_system.py
@@ -37,6 +37,7 @@ try:  # Syntax changed in OpenMM 7.6
         kelvin,
         kilocalories_per_mole,
         md_kilocalories,
+        nanometers,
         picoseconds,
     )
 except ImportError:
@@ -53,7 +54,7 @@ except ImportError:
     from simtk.openmm.app import CharmmCrdFile, CharmmParameterSet, CharmmPsfFile
     from simtk.openmm.app import PME, HBonds
     from simtk.openmm.app import Simulation
-    from simtk.unit import angstroms, kelvin, picoseconds
+    from simtk.unit import angstroms, kelvin, picoseconds, nanometers
 
 from ..reporter import ChargeReporter, EnergyReporter
 from ..system import ProtexSystem, ProtexTemplates
@@ -246,6 +247,7 @@ def test_create_IonicLiquid():
 
     count = defaultdict(int)
     ionic_liquid = ProtexSystem(simulation, templates)
+    print(ionic_liquid.boxlength.value_in_unit(nanometers))
 
     assert len(ionic_liquid.residues) == 1000
     for idx, residue in enumerate(ionic_liquid.residues):

--- a/protex/tests/test_update.py
+++ b/protex/tests/test_update.py
@@ -9,11 +9,11 @@ from scipy.spatial import distance_matrix
 try:
     from openmm import DrudeNoseHooverIntegrator, Platform, XmlSerializer
     from openmm.app import DCDReporter, PDBFile, Simulation, StateDataReporter
-    from openmm.unit import angstroms, kelvin, picoseconds
+    from openmm.unit import angstroms, kelvin, nanometers, picoseconds
 except ImportError:
     from simtk.openmm.app import StateDataReporter, DCDReporter, PDBFile, Simulation
     from simtk.openmm import XmlSerializer, Platform, DrudeNoseHooverIntegrator
-    from simtk.unit import angstroms, kelvin, picoseconds
+    from simtk.unit import angstroms, kelvin, picoseconds, nanometers
 
 import protex
 
@@ -1256,7 +1256,7 @@ def test_pbc():
     # wrap system in IonicLiquidSystem
     ionic_liquid = ProtexSystem(simulation, templates)
 
-    boxl = ionic_liquid.boxlength
+    boxl = ionic_liquid.boxlength.value_in_unit(nanometers)
     print(f"{boxl=}")
 
     update = NaiveMCUpdate(ionic_liquid)
@@ -1271,7 +1271,7 @@ def test_pbc():
 
     from scipy.spatial.distance import cdist
 
-    def _rPBC(coor1, coor2, boxl=boxl):
+    def _rPBC(coor1, coor2, boxl=ionic_liquid.boxlength.value_in_unit(nanometers)):
         dx = abs(coor1[0] - coor2[0])
         if dx > boxl / 2:
             dx = boxl - dx

--- a/protex/tests/test_update.py
+++ b/protex/tests/test_update.py
@@ -25,7 +25,55 @@ from ..testsystems import (
     generate_im1h_oac_system,
     generate_single_im1h_oac_system,
 )
-from ..update import NaiveMCUpdate, StateUpdate
+from ..update import Update, NaiveMCUpdate, KeepHUpdate, StateUpdate
+
+
+def test_create_update():
+    simulation = generate_im1h_oac_system()
+    allowed_updates = {}
+    allowed_updates[frozenset(["IM1H", "OAC"])] = {"r_max": 0.16, "prob": 1}
+    allowed_updates[frozenset(["IM1", "HOAC"])] = {"r_max": 0.16, "prob": 1}
+    templates = ProtexTemplates([OAC_HOAC, IM1H_IM1], (allowed_updates))
+    ionic_liquid = ProtexSystem(simulation, templates)
+    try:
+        update = Update(ionic_liquid)
+    except TypeError:
+        print("All fine, should raise TypeError, because abstract class")
+        pass
+
+    to_adapt = [("OAC", 150, frozenset(["IM1H", "OAC"]))]
+    try:
+        update = NaiveMCUpdate(
+            ionic_liquid,
+            all_forces=True,
+            to_adapt=to_adapt,
+            include_equivalent_atom=True,
+            # reorient=True,
+        )
+    except NotImplementedError as e:
+        pass
+
+    update = NaiveMCUpdate(
+        ionic_liquid,
+        all_forces=True,
+        to_adapt=to_adapt,
+        include_equivalent_atom=True,
+        # reorient=False,
+    )
+
+    state_update = StateUpdate(update)
+    state_update.update(2)
+
+    update = KeepHUpdate(
+        ionic_liquid,
+        all_forces=True,
+        to_adapt=to_adapt,
+        include_equivalent_atom=True,
+        reorient=False,
+    )
+
+    state_update = StateUpdate(update)
+    state_update.update(2)
 
 
 @pytest.mark.skipif(
@@ -180,10 +228,7 @@ def test_setting_forces():
     allowed_updates[frozenset(["IM1H", "IM1"])] = {"r_max": 0.16, "prob": 1}
     allowed_updates[frozenset(["HOAC", "OAC"])] = {"r_max": 0.16, "prob": 1}
     # get ionic liquid templates
-    templates = ProtexTemplates(
-        [OAC_HOAC, IM1H_IM1],
-        (allowed_updates),
-    )
+    templates = ProtexTemplates([OAC_HOAC, IM1H_IM1], (allowed_updates),)
     # wrap system in IonicLiquidSystem
     ionic_liquid = ProtexSystem(simulation, templates)
 
@@ -227,9 +272,7 @@ def test_setting_forces():
     int_force_0a = ionic_liquid.residues[0]._get_HarmonicBondForce_parameters_at_lambda(
         1.0
     )
-    ionic_liquid.residues[0]._set_HarmonicBondForce_parameters(
-        int_force_0a,
-    )
+    ionic_liquid.residues[0]._set_HarmonicBondForce_parameters(int_force_0a,)
     print("Lambda: 1.0")
     parm_lambda_10 = []
     for force in ionic_liquid.system.getForces():
@@ -417,9 +460,7 @@ def test_setting_forces():
     int_force_0a = ionic_liquid.residues[
         200
     ]._get_CustomTorsionForce_parameters_at_lambda(0.5)
-    ionic_liquid.residues[200]._set_CustomTorsionForce_parameters(
-        int_force_0a,
-    )
+    ionic_liquid.residues[200]._set_CustomTorsionForce_parameters(int_force_0a,)
     print("Lambda: 0.5")
     parm_lambda_05 = []
     for force in ionic_liquid.system.getForces():
@@ -442,9 +483,7 @@ def test_setting_forces():
     int_force_0a = ionic_liquid.residues[
         200
     ]._get_CustomTorsionForce_parameters_at_lambda(1.0)
-    ionic_liquid.residues[200]._set_CustomTorsionForce_parameters(
-        int_force_0a,
-    )
+    ionic_liquid.residues[200]._set_CustomTorsionForce_parameters(int_force_0a,)
     print("Lambda: 1.0")
     parm_lambda_10 = []
     for force in ionic_liquid.system.getForces():
@@ -501,9 +540,7 @@ def test_setting_forces():
 
     # update DrudeForce
     int_force_0a = ionic_liquid.residues[0]._get_DrudeForce_parameters_at_lambda(0.5)
-    ionic_liquid.residues[0]._set_DrudeForce_parameters(
-        int_force_0a,
-    )
+    ionic_liquid.residues[0]._set_DrudeForce_parameters(int_force_0a,)
     print("Lambda: 0.5")
     parm_lambda_05_charges_pol = []
     parm_lambda_05_thole = []
@@ -534,9 +571,7 @@ def test_setting_forces():
 
     # update DrudeForce
     int_force_0a = ionic_liquid.residues[0]._get_DrudeForce_parameters_at_lambda(1.0)
-    ionic_liquid.residues[0]._set_DrudeForce_parameters(
-        int_force_0a,
-    )
+    ionic_liquid.residues[0]._set_DrudeForce_parameters(int_force_0a,)
     print("Lambda: 1.0")
     parm_lambda_10_charges_pol = []
     parm_lambda_10_thole = []
@@ -576,8 +611,7 @@ def test_setting_forces():
 
 
 @pytest.mark.skipif(
-    os.getenv("CI") == "true",
-    reason="Will fail sporadicaly.",
+    os.getenv("CI") == "true", reason="Will fail sporadicaly.",
 )
 def test_single_update(caplog):
     # caplog.set_level(logging.DEBUG)
@@ -649,8 +683,7 @@ def test_single_update(caplog):
 
 
 @pytest.mark.skipif(
-    os.getenv("CI") == "true",
-    reason="Will fail sporadicaly.",
+    os.getenv("CI") == "true", reason="Will fail sporadicaly.",
 )
 def test_check_updated_charges(caplog):
     caplog.set_level(logging.DEBUG)
@@ -716,8 +749,7 @@ def test_check_updated_charges(caplog):
 
 
 @pytest.mark.skipif(
-    os.getenv("CI") == "true",
-    reason="Takes too long for github actions",
+    os.getenv("CI") == "true", reason="Takes too long for github actions",
 )
 def test_transfer_with_distance_matrix():
 
@@ -819,8 +851,7 @@ def test_transfer_with_distance_matrix():
 
 
 @pytest.mark.skipif(
-    os.getenv("CI") == "true",
-    reason="Will fail sporadicaly.",
+    os.getenv("CI") == "true", reason="Will fail sporadicaly.",
 )
 def test_updates(caplog):
     caplog.set_level(logging.DEBUG)
@@ -940,8 +971,7 @@ def test_dry_updates(caplog):
 
 
 @pytest.mark.skipif(
-    os.getenv("CI") == "true",
-    reason="Will fail sporadicaly.",
+    os.getenv("CI") == "true", reason="Will fail sporadicaly.",
 )
 def test_parameters_after_update():
 
@@ -1131,9 +1161,12 @@ def test_parameters_after_update():
 
     print(f"{imp_before_list=}, {imp_after_list=}")
 
-    for pos, (
-        (b_drude, b_parent, _, _, _, b_charge, b_pol, _, _),
-        (a_drude, a_parent, _, _, _, a_charge, a_pol, _, _),
+    for (
+        pos,
+        (
+            (b_drude, b_parent, _, _, _, b_charge, b_pol, _, _),
+            (a_drude, a_parent, _, _, _, a_charge, a_pol, _, _),
+        ),
     ) in enumerate(zip(drude_before_list, drude_after_list)):
         if b_charge != a_charge:
             print(f"Charge changed: {pos=}, {b_charge=}, {a_charge=}")
@@ -1146,9 +1179,9 @@ def test_parameters_after_update():
     ):
         if b_thole != a_thole:
             print(f"Thole changed: {pos=}, {b_thole=}, {a_thole=}")
-    for pos, (
-        (b1, b2, b3, b4, (b_k, b_psi0)),
-        (a1, a2, a3, a4, (a_k, a_psi0)),
+    for (
+        pos,
+        ((b1, b2, b3, b4, (b_k, b_psi0)), (a1, a2, a3, a4, (a_k, a_psi0)),),
     ) in enumerate(zip(imp_before_list, imp_after_list)):
         if b_k != a_k:
             print(f"k changed: {pos=}, {b_k=}, {a_k=}")
@@ -1181,8 +1214,7 @@ def test_parameters_after_update():
 
 
 @pytest.mark.skipif(
-    os.getenv("CI") == "true",
-    reason="Will fail sporadicaly.",
+    os.getenv("CI") == "true", reason="Will fail sporadicaly.",
 )
 def test_pbc():
 
@@ -1234,8 +1266,7 @@ def test_pbc():
 
 
 @pytest.mark.skipif(
-    os.getenv("CI") == "true",
-    reason="Will fail sporadicaly.",
+    os.getenv("CI") == "true", reason="Will fail sporadicaly.",
 )
 def test_single_im1h_oac():
 
@@ -1391,8 +1422,7 @@ def test_force_selection():
 
 
 @pytest.mark.skipif(
-    os.getenv("CI") == "true",
-    reason="Will fail sporadicaly.",
+    os.getenv("CI") == "true", reason="Will fail sporadicaly.",
 )
 def test_update_all_forces(caplog):
     caplog.set_level(logging.DEBUG)
@@ -1427,8 +1457,7 @@ def test_update_all_forces(caplog):
 
 
 @pytest.mark.skipif(
-    os.getenv("CI") == "true",
-    reason="Will fail sporadicaly.",
+    os.getenv("CI") == "true", reason="Will fail sporadicaly.",
 )
 def test_energy_before_after():
     def get_time_energy(simulation, print=False):
@@ -1523,8 +1552,7 @@ def test_energy_before_after():
 
 
 @pytest.mark.skipif(
-    os.getenv("CI") == "true",
-    reason="Will fail sporadicaly.",
+    os.getenv("CI") == "true", reason="Will fail sporadicaly.",
 )
 def test_single_energy_before_after(caplog):
     caplog.set_level(logging.DEBUG)
@@ -1673,8 +1701,7 @@ def test_single_energy_before_after(caplog):
 
 
 @pytest.mark.skipif(
-    os.getenv("CI") == "true",
-    reason="Will fail sporadicaly.",
+    os.getenv("CI") == "true", reason="Will fail sporadicaly.",
 )
 def test_dummy_energy_before_after(caplog):
     caplog.set_level(logging.DEBUG)
@@ -1688,8 +1715,7 @@ def test_dummy_energy_before_after(caplog):
 
     def save_il(ionic_liquid, number):
         ionic_liquid.write_psf(
-            f"protex/forcefield/dummy/im1h_oac_im1_hoac_1.psf",
-            f"test_{number}.psf",
+            f"protex/forcefield/dummy/im1h_oac_im1_hoac_1.psf", f"test_{number}.psf",
         )
         ionic_liquid.saveCheckpoint(f"test_{number}.rst")
 
@@ -1823,8 +1849,7 @@ def test_dummy_energy_before_after(caplog):
 
 
 @pytest.mark.skipif(
-    os.getenv("CI") == "true",
-    reason="Will fail sporadicaly.",
+    os.getenv("CI") == "true", reason="Will fail sporadicaly.",
 )
 def test_periodictorsionforce_energy(caplog):
     # caplog.set_level(logging.DEBUG)
@@ -2010,8 +2035,7 @@ def test_ubforce_update(caplog):
 
 
 @pytest.mark.skipif(
-    os.getenv("CI") == "true",
-    reason="Will fail sporadicaly.",
+    os.getenv("CI") == "true", reason="Will fail sporadicaly.",
 )
 def test_single_energy_molecule(caplog):
     caplog.set_level(logging.DEBUG)
@@ -2179,8 +2203,7 @@ def test_single_energy_molecule(caplog):
 
 
 @pytest.mark.skipif(
-    os.getenv("CI") == "true",
-    reason="Will fail sporadicaly.",
+    os.getenv("CI") == "true", reason="Will fail sporadicaly.",
 )
 def test_wrong_atom_name(caplog):
     caplog.set_level(logging.DEBUG)

--- a/protex/tests/test_update.py
+++ b/protex/tests/test_update.py
@@ -28,6 +28,10 @@ from ..testsystems import (
 from ..update import KeepHUpdate, NaiveMCUpdate, StateUpdate, Update
 
 
+@pytest.mark.skipif(
+    os.getenv("CI") == "true",
+    reason="Fails sporadically",
+)
 def test_create_update():
     simulation = generate_im1h_oac_system()
     allowed_updates = {}

--- a/protex/tests/test_update.py
+++ b/protex/tests/test_update.py
@@ -228,7 +228,10 @@ def test_setting_forces():
     allowed_updates[frozenset(["IM1H", "IM1"])] = {"r_max": 0.16, "prob": 1}
     allowed_updates[frozenset(["HOAC", "OAC"])] = {"r_max": 0.16, "prob": 1}
     # get ionic liquid templates
-    templates = ProtexTemplates([OAC_HOAC, IM1H_IM1], (allowed_updates),)
+    templates = ProtexTemplates(
+        [OAC_HOAC, IM1H_IM1],
+        (allowed_updates),
+    )
     # wrap system in IonicLiquidSystem
     ionic_liquid = ProtexSystem(simulation, templates)
 
@@ -272,7 +275,9 @@ def test_setting_forces():
     int_force_0a = ionic_liquid.residues[0]._get_HarmonicBondForce_parameters_at_lambda(
         1.0
     )
-    ionic_liquid.residues[0]._set_HarmonicBondForce_parameters(int_force_0a,)
+    ionic_liquid.residues[0]._set_HarmonicBondForce_parameters(
+        int_force_0a,
+    )
     print("Lambda: 1.0")
     parm_lambda_10 = []
     for force in ionic_liquid.system.getForces():
@@ -460,7 +465,9 @@ def test_setting_forces():
     int_force_0a = ionic_liquid.residues[
         200
     ]._get_CustomTorsionForce_parameters_at_lambda(0.5)
-    ionic_liquid.residues[200]._set_CustomTorsionForce_parameters(int_force_0a,)
+    ionic_liquid.residues[200]._set_CustomTorsionForce_parameters(
+        int_force_0a,
+    )
     print("Lambda: 0.5")
     parm_lambda_05 = []
     for force in ionic_liquid.system.getForces():
@@ -483,7 +490,9 @@ def test_setting_forces():
     int_force_0a = ionic_liquid.residues[
         200
     ]._get_CustomTorsionForce_parameters_at_lambda(1.0)
-    ionic_liquid.residues[200]._set_CustomTorsionForce_parameters(int_force_0a,)
+    ionic_liquid.residues[200]._set_CustomTorsionForce_parameters(
+        int_force_0a,
+    )
     print("Lambda: 1.0")
     parm_lambda_10 = []
     for force in ionic_liquid.system.getForces():
@@ -540,7 +549,9 @@ def test_setting_forces():
 
     # update DrudeForce
     int_force_0a = ionic_liquid.residues[0]._get_DrudeForce_parameters_at_lambda(0.5)
-    ionic_liquid.residues[0]._set_DrudeForce_parameters(int_force_0a,)
+    ionic_liquid.residues[0]._set_DrudeForce_parameters(
+        int_force_0a,
+    )
     print("Lambda: 0.5")
     parm_lambda_05_charges_pol = []
     parm_lambda_05_thole = []
@@ -571,7 +582,9 @@ def test_setting_forces():
 
     # update DrudeForce
     int_force_0a = ionic_liquid.residues[0]._get_DrudeForce_parameters_at_lambda(1.0)
-    ionic_liquid.residues[0]._set_DrudeForce_parameters(int_force_0a,)
+    ionic_liquid.residues[0]._set_DrudeForce_parameters(
+        int_force_0a,
+    )
     print("Lambda: 1.0")
     parm_lambda_10_charges_pol = []
     parm_lambda_10_thole = []
@@ -611,7 +624,8 @@ def test_setting_forces():
 
 
 @pytest.mark.skipif(
-    os.getenv("CI") == "true", reason="Will fail sporadicaly.",
+    os.getenv("CI") == "true",
+    reason="Will fail sporadicaly.",
 )
 def test_single_update(caplog):
     # caplog.set_level(logging.DEBUG)
@@ -683,7 +697,8 @@ def test_single_update(caplog):
 
 
 @pytest.mark.skipif(
-    os.getenv("CI") == "true", reason="Will fail sporadicaly.",
+    os.getenv("CI") == "true",
+    reason="Will fail sporadicaly.",
 )
 def test_check_updated_charges(caplog):
     caplog.set_level(logging.DEBUG)
@@ -749,7 +764,8 @@ def test_check_updated_charges(caplog):
 
 
 @pytest.mark.skipif(
-    os.getenv("CI") == "true", reason="Takes too long for github actions",
+    os.getenv("CI") == "true",
+    reason="Takes too long for github actions",
 )
 def test_transfer_with_distance_matrix():
 
@@ -851,7 +867,8 @@ def test_transfer_with_distance_matrix():
 
 
 @pytest.mark.skipif(
-    os.getenv("CI") == "true", reason="Will fail sporadicaly.",
+    os.getenv("CI") == "true",
+    reason="Will fail sporadicaly.",
 )
 def test_updates(caplog):
     caplog.set_level(logging.DEBUG)
@@ -971,7 +988,8 @@ def test_dry_updates(caplog):
 
 
 @pytest.mark.skipif(
-    os.getenv("CI") == "true", reason="Will fail sporadicaly.",
+    os.getenv("CI") == "true",
+    reason="Will fail sporadicaly.",
 )
 def test_parameters_after_update():
 
@@ -1181,7 +1199,10 @@ def test_parameters_after_update():
             print(f"Thole changed: {pos=}, {b_thole=}, {a_thole=}")
     for (
         pos,
-        ((b1, b2, b3, b4, (b_k, b_psi0)), (a1, a2, a3, a4, (a_k, a_psi0)),),
+        (
+            (b1, b2, b3, b4, (b_k, b_psi0)),
+            (a1, a2, a3, a4, (a_k, a_psi0)),
+        ),
     ) in enumerate(zip(imp_before_list, imp_after_list)):
         if b_k != a_k:
             print(f"k changed: {pos=}, {b_k=}, {a_k=}")
@@ -1214,7 +1235,8 @@ def test_parameters_after_update():
 
 
 @pytest.mark.skipif(
-    os.getenv("CI") == "true", reason="Will fail sporadicaly.",
+    os.getenv("CI") == "true",
+    reason="Will fail sporadicaly.",
 )
 def test_pbc():
 
@@ -1266,7 +1288,8 @@ def test_pbc():
 
 
 @pytest.mark.skipif(
-    os.getenv("CI") == "true", reason="Will fail sporadicaly.",
+    os.getenv("CI") == "true",
+    reason="Will fail sporadicaly.",
 )
 def test_single_im1h_oac():
 
@@ -1422,7 +1445,8 @@ def test_force_selection():
 
 
 @pytest.mark.skipif(
-    os.getenv("CI") == "true", reason="Will fail sporadicaly.",
+    os.getenv("CI") == "true",
+    reason="Will fail sporadicaly.",
 )
 def test_update_all_forces(caplog):
     caplog.set_level(logging.DEBUG)
@@ -1457,7 +1481,8 @@ def test_update_all_forces(caplog):
 
 
 @pytest.mark.skipif(
-    os.getenv("CI") == "true", reason="Will fail sporadicaly.",
+    os.getenv("CI") == "true",
+    reason="Will fail sporadicaly.",
 )
 def test_energy_before_after():
     def get_time_energy(simulation, print=False):
@@ -1552,7 +1577,8 @@ def test_energy_before_after():
 
 
 @pytest.mark.skipif(
-    os.getenv("CI") == "true", reason="Will fail sporadicaly.",
+    os.getenv("CI") == "true",
+    reason="Will fail sporadicaly.",
 )
 def test_single_energy_before_after(caplog):
     caplog.set_level(logging.DEBUG)
@@ -1701,7 +1727,8 @@ def test_single_energy_before_after(caplog):
 
 
 @pytest.mark.skipif(
-    os.getenv("CI") == "true", reason="Will fail sporadicaly.",
+    os.getenv("CI") == "true",
+    reason="Will fail sporadicaly.",
 )
 def test_dummy_energy_before_after(caplog):
     caplog.set_level(logging.DEBUG)
@@ -1715,7 +1742,8 @@ def test_dummy_energy_before_after(caplog):
 
     def save_il(ionic_liquid, number):
         ionic_liquid.write_psf(
-            f"protex/forcefield/dummy/im1h_oac_im1_hoac_1.psf", f"test_{number}.psf",
+            f"protex/forcefield/dummy/im1h_oac_im1_hoac_1.psf",
+            f"test_{number}.psf",
         )
         ionic_liquid.saveCheckpoint(f"test_{number}.rst")
 
@@ -1849,7 +1877,8 @@ def test_dummy_energy_before_after(caplog):
 
 
 @pytest.mark.skipif(
-    os.getenv("CI") == "true", reason="Will fail sporadicaly.",
+    os.getenv("CI") == "true",
+    reason="Will fail sporadicaly.",
 )
 def test_periodictorsionforce_energy(caplog):
     # caplog.set_level(logging.DEBUG)
@@ -2035,7 +2064,8 @@ def test_ubforce_update(caplog):
 
 
 @pytest.mark.skipif(
-    os.getenv("CI") == "true", reason="Will fail sporadicaly.",
+    os.getenv("CI") == "true",
+    reason="Will fail sporadicaly.",
 )
 def test_single_energy_molecule(caplog):
     caplog.set_level(logging.DEBUG)
@@ -2203,7 +2233,8 @@ def test_single_energy_molecule(caplog):
 
 
 @pytest.mark.skipif(
-    os.getenv("CI") == "true", reason="Will fail sporadicaly.",
+    os.getenv("CI") == "true",
+    reason="Will fail sporadicaly.",
 )
 def test_wrong_atom_name(caplog):
     caplog.set_level(logging.DEBUG)

--- a/protex/tests/test_update.py
+++ b/protex/tests/test_update.py
@@ -25,7 +25,7 @@ from ..testsystems import (
     generate_im1h_oac_system,
     generate_single_im1h_oac_system,
 )
-from ..update import Update, NaiveMCUpdate, KeepHUpdate, StateUpdate
+from ..update import KeepHUpdate, NaiveMCUpdate, StateUpdate, Update
 
 
 def test_create_update():

--- a/protex/testsystems.py
+++ b/protex/testsystems.py
@@ -1294,6 +1294,7 @@ MEOH_MEOH2 = {
     },
     "MEOH2": {
         "atom_name": "HO2",
+        "other_h": "HO1",
         "canonical_name": "MEOH",
     },
 }

--- a/protex/testsystems.py
+++ b/protex/testsystems.py
@@ -1268,6 +1268,7 @@ IM1H_IM1 = {
 OAC_HOAC = {
     "OAC": {
         "atom_name": "O2",
+        "other_o": "O1",
         "canonical_name": "OAC",  # Not needed?
     },
     "HOAC": {

--- a/protex/testsystems.py
+++ b/protex/testsystems.py
@@ -1268,7 +1268,7 @@ IM1H_IM1 = {
 OAC_HOAC = {
     "OAC": {
         "atom_name": "O2",
-        "other_o": "O1",
+        "equivalent_atom": "O1",
         "canonical_name": "OAC",  # Not needed?
     },
     "HOAC": {

--- a/protex/testsystems.py
+++ b/protex/testsystems.py
@@ -1291,11 +1291,9 @@ HPTSH_HPTS = {
 MEOH_MEOH2 = {
     "MEOH": {
         "atom_name": "O1",
-        "canonical_name": "MEOH",
     },
     "MEOH2": {
         "atom_name": "HO2",
-        "other_h": "HO1",
-        "canonical_name": "MEOH",
+        "equivalent_atom": "HO1",
     },
 }

--- a/protex/update.py
+++ b/protex/update.py
@@ -77,7 +77,7 @@ class NaiveMCUpdate(Update):
 
         positions = self.ionic_liquid.simulation.context.getState(
             getPositions=True
-        ).getPositions(asNumpy=False) 
+        ).getPositions(asNumpy=False)
 
         positions_copy = copy.deepcopy(positions)
 
@@ -96,8 +96,6 @@ class NaiveMCUpdate(Update):
 
     def _update(self, candidates: list[tuple], nr_of_steps: int):
         logger.info("called _update")
-
-       
 
         # get current state
         state = self.ionic_liquid.simulation.context.getState(getEnergy=True)
@@ -160,7 +158,7 @@ class NaiveMCUpdate(Update):
         # all these lists are not needed, if contents used in the same loop (as it is currently)
 
         for candidate in candidates:
-            candidate1_residue, candidate2_residue = candidate 
+            candidate1_residue, candidate2_residue = candidate
 
             if "H" in self.ionic_liquid.templates.get_atom_name_for(
                 candidate1_residue.current_name
@@ -198,8 +196,6 @@ class NaiveMCUpdate(Update):
                     )
                 ]
 
-        
-
             if acceptor.used_equivalent_atom == True:
                 pos_acceptor_atom = positions_copy[
                     acceptor.get_idx_for_atom_name(
@@ -221,40 +217,50 @@ class NaiveMCUpdate(Update):
             pos_acceptor_atoms.append(pos_acceptor_atom)
 
             # account for PBC
-            boxl_vec = self.ionic_liquid.boxlength*pos_donated_H[0]/pos_donated_H[0]._value # very stupid workaround to get a quantity with unit from a number
+            boxl_vec = (
+                self.ionic_liquid.boxlength * pos_donated_H[0] / pos_donated_H[0]._value
+            )  # very stupid workaround to get a quantity with unit from a number
 
-            for i in range(0,3):
-                if abs(pos_acceptor_atom[i] - pos_donated_H[i]) > boxl_vec/2: # could also be some other value
+            for i in range(0, 3):
+                if (
+                    abs(pos_acceptor_atom[i] - pos_donated_H[i]) > boxl_vec / 2
+                ):  # could also be some other value
                     if pos_acceptor_atom[i] > pos_donated_H[i]:
                         pos_donated_H[i] = pos_donated_H[i] + boxl_vec
                     else:
                         pos_donated_H[i] = pos_donated_H[i] - boxl_vec
 
             pos_donated_Hs.append(pos_donated_H)
-            pos_accepted_H = pos_donated_H - 0.33 * (pos_donated_H - pos_acceptor_atom) # set position at ca. 1 angstrom from acceptor -> maybe more stable?
+            pos_accepted_H = pos_donated_H - 0.33 * (
+                pos_donated_H - pos_acceptor_atom
+            )  # set position at ca. 1 angstrom from acceptor -> maybe more stable?
             pos_accepted_Hs.append(pos_accepted_H)
             ###
 
             # reorient equivalent atoms if needed
             if candidate1_residue.used_equivalent_atom:
                 candidate1_residue.used_equivalent_atom = (
-                False  # reset for next update round
-            )
+                    False  # reset for next update round
+                )
                 self._reorient_atoms(candidate1_residue)
                 # troubleshooting reorient
                 atom_idx = candidate1_residue.get_idx_for_atom_name(
-                self.ionic_liquid.templates.get_atom_name_for(candidate1_residue.current_name)
+                    self.ionic_liquid.templates.get_atom_name_for(
+                        candidate1_residue.current_name
+                    )
                 )
                 equivalent_idx = candidate1_residue.get_idx_for_atom_name(
-                    self.ionic_liquid.templates.get_equivalent_atom_for(candidate1_residue.current_name)
+                    self.ionic_liquid.templates.get_equivalent_atom_for(
+                        candidate1_residue.current_name
+                    )
                 )
 
                 positions = self.ionic_liquid.simulation.context.getState(
                     getPositions=True
-                ).getPositions(asNumpy=False) 
+                ).getPositions(asNumpy=False)
 
                 print(
-                f"position of {self.ionic_liquid.templates.get_atom_name_for(candidate1_residue.current_name)} : {positions[atom_idx]} and {self.ionic_liquid.templates.get_equivalent_atom_for(candidate1_residue.current_name)} : {positions[equivalent_idx]}"
+                    f"position of {self.ionic_liquid.templates.get_atom_name_for(candidate1_residue.current_name)} : {positions[atom_idx]} and {self.ionic_liquid.templates.get_equivalent_atom_for(candidate1_residue.current_name)} : {positions[equivalent_idx]}"
                 )
                 # troubleshoot end
 
@@ -263,18 +269,22 @@ class NaiveMCUpdate(Update):
                 self._reorient_atoms(candidate2_residue)
                 # troubleshooting reorient
                 atom_idx = candidate2_residue.get_idx_for_atom_name(
-                self.ionic_liquid.templates.get_atom_name_for(candidate2_residue.current_name)
+                    self.ionic_liquid.templates.get_atom_name_for(
+                        candidate2_residue.current_name
+                    )
                 )
                 equivalent_idx = candidate2_residue.get_idx_for_atom_name(
-                    self.ionic_liquid.templates.get_equivalent_atom_for(candidate2_residue.current_name)
+                    self.ionic_liquid.templates.get_equivalent_atom_for(
+                        candidate2_residue.current_name
+                    )
                 )
 
                 positions = self.ionic_liquid.simulation.context.getState(
                     getPositions=True
-                ).getPositions(asNumpy=False) 
+                ).getPositions(asNumpy=False)
 
                 print(
-                f"position of {self.ionic_liquid.templates.get_atom_name_for(candidate2_residue.current_name)} : {positions[atom_idx]} and {self.ionic_liquid.templates.get_equivalent_atom_for(candidate2_residue.current_name)} : {positions[equivalent_idx]}"
+                    f"position of {self.ionic_liquid.templates.get_atom_name_for(candidate2_residue.current_name)} : {positions[atom_idx]} and {self.ionic_liquid.templates.get_equivalent_atom_for(candidate2_residue.current_name)} : {positions[equivalent_idx]}"
                 )
                 # troubleshoot end
 

--- a/protex/update.py
+++ b/protex/update.py
@@ -245,52 +245,52 @@ class NaiveMCUpdate(Update):
                     False  # reset for next update round
                 )
                 self._reorient_atoms(candidate1_residue)
-                # troubleshooting reorient
-                atom_idx = candidate1_residue.get_idx_for_atom_name(
-                    self.ionic_liquid.templates.get_atom_name_for(
-                        candidate1_residue.current_name
-                    )
-                )
-                equivalent_idx = candidate1_residue.get_idx_for_atom_name(
-                    self.ionic_liquid.templates.get_equivalent_atom_for(
-                        candidate1_residue.current_name
-                    )
-                )
+                # # troubleshooting reorient
+                # atom_idx = candidate1_residue.get_idx_for_atom_name(
+                #     self.ionic_liquid.templates.get_atom_name_for(
+                #         candidate1_residue.current_name
+                #     )
+                # )
+                # equivalent_idx = candidate1_residue.get_idx_for_atom_name(
+                #     self.ionic_liquid.templates.get_equivalent_atom_for(
+                #         candidate1_residue.current_name
+                #     )
+                # )
 
-                positions = self.ionic_liquid.simulation.context.getState(
-                    getPositions=True
-                ).getPositions(asNumpy=False)
+                # positions = self.ionic_liquid.simulation.context.getState(
+                #     getPositions=True
+                # ).getPositions(asNumpy=False)
 
-                print(
-                    f"position of {self.ionic_liquid.templates.get_atom_name_for(candidate1_residue.current_name)} : {positions[atom_idx]} and {self.ionic_liquid.templates.get_equivalent_atom_for(candidate1_residue.current_name)} : {positions[equivalent_idx]}"
-                )
-                # troubleshoot end
+                # print(
+                #     f"position of {self.ionic_liquid.templates.get_atom_name_for(candidate1_residue.current_name)} : {positions[atom_idx]} and {self.ionic_liquid.templates.get_equivalent_atom_for(candidate1_residue.current_name)} : {positions[equivalent_idx]}"
+                # )
+                # # troubleshoot end
 
             if candidate2_residue.used_equivalent_atom:
                 candidate2_residue.used_equivalent_atom = False
                 self._reorient_atoms(candidate2_residue)
-                # troubleshooting reorient
-                atom_idx = candidate2_residue.get_idx_for_atom_name(
-                    self.ionic_liquid.templates.get_atom_name_for(
-                        candidate2_residue.current_name
-                    )
-                )
-                equivalent_idx = candidate2_residue.get_idx_for_atom_name(
-                    self.ionic_liquid.templates.get_equivalent_atom_for(
-                        candidate2_residue.current_name
-                    )
-                )
+                # # troubleshooting reorient
+                # atom_idx = candidate2_residue.get_idx_for_atom_name(
+                #     self.ionic_liquid.templates.get_atom_name_for(
+                #         candidate2_residue.current_name
+                #     )
+                # )
+                # equivalent_idx = candidate2_residue.get_idx_for_atom_name(
+                #     self.ionic_liquid.templates.get_equivalent_atom_for(
+                #         candidate2_residue.current_name
+                #     )
+                # )
 
-                positions = self.ionic_liquid.simulation.context.getState(
-                    getPositions=True
-                ).getPositions(asNumpy=False)
+                # positions = self.ionic_liquid.simulation.context.getState(
+                #     getPositions=True
+                # ).getPositions(asNumpy=False)
 
-                print(
-                    f"position of {self.ionic_liquid.templates.get_atom_name_for(candidate2_residue.current_name)} : {positions[atom_idx]} and {self.ionic_liquid.templates.get_equivalent_atom_for(candidate2_residue.current_name)} : {positions[equivalent_idx]}"
-                )
-                # troubleshoot end
+                # print(
+                #     f"position of {self.ionic_liquid.templates.get_atom_name_for(candidate2_residue.current_name)} : {positions[atom_idx]} and {self.ionic_liquid.templates.get_equivalent_atom_for(candidate2_residue.current_name)} : {positions[equivalent_idx]}"
+                # )
+                # # troubleshoot end
 
-            # # also update has_equivalent_atom
+            # # also update has_equivalent_atom (not needed if has_equivalent_atom updated via self.ionic_liquid.templates.has_equivalent_atom(residue.current_name))
             # if candidate1_residue.current_name in ("MEOH2", "MEOH", "HOAC", "OAC"):
             #     candidate1_residue.has_equivalent_atom = (
             #         not candidate1_residue.has_equivalent_atom
@@ -316,12 +316,14 @@ class NaiveMCUpdate(Update):
 
             # update position of the once-dummy H to that of the donated H (a bit closer to the acceptor to avoid LJ collusion with the now dummy H)
             positions[idx_accepted_H] = pos_accepted_Hs[candidates.index(candidate)]
-            print(
-                f"acceptor: {pos_acceptor_atoms[candidates.index(candidate)]}, donor_H: {pos_donated_Hs[candidates.index(candidate)]}"
-            )
-            print(
-                f"setting position of {self.ionic_liquid.templates.get_atom_name_for(acceptor.current_name)} of {acceptor.current_name}:{acceptor.residue.index} to {pos_accepted_Hs[candidates.index(candidate)]}"
-            )
+            # # troubleshooting
+            # print(
+            #     f"acceptor: {pos_acceptor_atoms[candidates.index(candidate)]}, donor_H: {pos_donated_Hs[candidates.index(candidate)]}"
+            # )
+            # print(
+            #     f"setting position of {self.ionic_liquid.templates.get_atom_name_for(acceptor.current_name)} of {acceptor.current_name}:{acceptor.residue.index} to {pos_accepted_Hs[candidates.index(candidate)]}"
+            # )
+            # # troubleshooting end
 
         self.ionic_liquid.simulation.context.setPositions(positions)
         # NOTE: should this happen directly after the simulation steps if there are multiple steps within the update?

--- a/protex/update.py
+++ b/protex/update.py
@@ -66,13 +66,17 @@ class NaiveMCUpdate(Update):
     def _reorient_atoms(self, candidate):
         # Function to reorient atoms if the equivalent atom was used for shortest distance
         # something like: getPositions, change coordinates of dummy and real H, setPositions -> only works for MEOH
-    
+
         positions = self.ionic_liquid.simulation.context.getState(
             getPositions=True
         ).getPositions(asNumpy=True)
 
-        atom_idx = candidate.get_idx_for_atom_name(self.ionic_liquid.templates.get_atom_name_for(candidate.current_name))
-        equivalent_idx = candidate.get_idx_for_atom_name(self.ionic_liquid.templates.get_equivalent_atom_for(candidate.current_name))
+        atom_idx = candidate.get_idx_for_atom_name(
+            self.ionic_liquid.templates.get_atom_name_for(candidate.current_name)
+        )
+        equivalent_idx = candidate.get_idx_for_atom_name(
+            self.ionic_liquid.templates.get_equivalent_atom_for(candidate.current_name)
+        )
         pos_atom = positions[atom_idx]
         pos_equivalent = positions[equivalent_idx]
 
@@ -94,10 +98,12 @@ class NaiveMCUpdate(Update):
         # TODO:
         for candidate in candidates:
             candidate1_residue, candidate2_residue = sorted(
-                    candidate, key=lambda candidate: candidate.current_name
-                )
+                candidate, key=lambda candidate: candidate.current_name
+            )
             if candidate1_residue.used_equivalent_atom:
-                candidate1_residue.used_equivalent_atom = False # reset for next update round
+                candidate1_residue.used_equivalent_atom = (
+                    False  # reset for next update round
+                )
                 self._reorient_atoms(candidate1_residue)
             if candidate2_residue.used_equivalent_atom:
                 candidate2_residue.used_equivalent_atom = False
@@ -404,7 +410,9 @@ class StateUpdate:
                     proposed_candidate_pair = (residue1, residue2)
                     # reject if already used in this transfer call
                     # print(f"{residue1=}, {residue2=}")
-                    if residue1 in used_residues or residue2 in used_residues: #TODO: is this working with changing some variables in the classes?
+                    if (
+                        residue1 in used_residues or residue2 in used_residues
+                    ):  # TODO: is this working with changing some variables in the classes?
                         logger.debug(
                             f"{residue1.current_name}:{residue1.residue.id}:{charge_candidate_idx1}-{residue2.current_name}:{residue2.residue.id}:{charge_candidate_idx2} pair rejected, bc used this transfer call ..."
                         )
@@ -418,7 +426,9 @@ class StateUpdate:
                         continue
                     # accept otherwise
                     proposed_candidate_pairs.append(proposed_candidate_pair)
-                    if candidate_idx1 == residue1.equivalent_atom_pos_in_list: # check if we used the actual atom or onyl the equivalent
+                    if (
+                        candidate_idx1 == residue1.equivalent_atom_pos_in_list
+                    ):  # check if we used the actual atom or onyl the equivalent
                         residue1.used_equivalent_atom = True
                     if candidate_idx2 == residue2.equivalent_atom_pos_in_list:
                         residue2.used_equivalent_atom = True
@@ -455,7 +465,9 @@ class StateUpdate:
             pos_list.append(
                 pos[
                     residue.get_idx_for_atom_name(
-                        self.ionic_liquid.templates.get_atom_name_for(residue.current_name)
+                        self.ionic_liquid.templates.get_atom_name_for(
+                            residue.current_name
+                        )
                     )
                     # this needs the atom idx to be the same for both topologies
                     # TODO: maybe get rid of this caveat
@@ -468,14 +480,17 @@ class StateUpdate:
                 pos_list.append(
                     pos[
                         residue.get_idx_for_atom_name(
-                            self.ionic_liquid.templates.get_equivalent_atom_for(residue.current_name)
+                            self.ionic_liquid.templates.get_equivalent_atom_for(
+                                residue.current_name
+                            )
                         )
                     ]
                 )
-                residue.equivalent_atom_pos_in_list = len(res_list) # store idx to know which coordinates where used for distance
+                residue.equivalent_atom_pos_in_list = len(
+                    res_list
+                )  # store idx to know which coordinates where used for distance
                 res_list.append(
                     residue
                 )  # add second time the residue to have same length of pos_list and res_list
-
 
         return pos_list, res_list

--- a/protex/update.py
+++ b/protex/update.py
@@ -73,9 +73,10 @@ class NaiveMCUpdate(Update):
         equivalent_idx = candidate.get_idx_for_atom_name(
             self.ionic_liquid.templates.get_equivalent_atom_for(candidate.current_name)
         )
-        pos_atom = positions[atom_idx]
+        positions_copy = positions.copy()
+        pos_atom = positions_copy[atom_idx]
         print(f"{pos_atom=}")
-        pos_equivalent = positions[equivalent_idx]
+        pos_equivalent = positions_copy[equivalent_idx]
         print(f"{pos_equivalent=}")
 
         positions[atom_idx] = pos_equivalent

--- a/protex/update.py
+++ b/protex/update.py
@@ -1,7 +1,7 @@
 import logging
 import random
-from collections import Counter
 from abc import ABC, abstractmethod
+from collections import Counter
 
 import numpy as np
 from scipy.spatial import distance_matrix

--- a/protex/update.py
+++ b/protex/update.py
@@ -88,13 +88,21 @@ class NaiveMCUpdate(Update):
         # TODO:
         for candidate in candidates:
             candidate1_residue, candidate2_residue = sorted(
-                    candidate, key=lambda candidate: candidate.current_name
-                )
+                candidate, key=lambda candidate: candidate.current_name
+            )
         positions = self.ionic_liquid.simulation.context.getState(
             getPositions=True
         ).getPositions(asNumpy=True)
 
-        if "H" in self.ionic_liquid.templates.get_atom_name_for(candidate1_residue.current_name) or (candidate1_residue.has_equivalent_atom == True and "H" in self.ionic_liquid.templates.get_equivalent_atom_for(candidate1_residue.current_name)):
+        if "H" in self.ionic_liquid.templates.get_atom_name_for(
+            candidate1_residue.current_name
+        ) or (
+            candidate1_residue.has_equivalent_atom == True
+            and "H"
+            in self.ionic_liquid.templates.get_equivalent_atom_for(
+                candidate1_residue.current_name
+            )
+        ):
             donor = candidate1_residue
             acceptor = candidate2_residue
         else:
@@ -102,9 +110,19 @@ class NaiveMCUpdate(Update):
             acceptor = candidate1_residue
 
         if donor.used_equivalent_atom == True:
-            pos_donated_H = positions[donor.get_idx_for_atom_name(self.ionic_liquid.templates.get_equivalent_atom_for(donor.current_name))]
+            pos_donated_H = positions[
+                donor.get_idx_for_atom_name(
+                    self.ionic_liquid.templates.get_equivalent_atom_for(
+                        donor.current_name
+                    )
+                )
+            ]
         else:
-            pos_donated_H = positions[donor.get_idx_for_atom_name(self.ionic_liquid.templates.get_atom_name_for(donor.current_name))]
+            pos_donated_H = positions[
+                donor.get_idx_for_atom_name(
+                    self.ionic_liquid.templates.get_atom_name_for(donor.current_name)
+                )
+            ]
 
         # get current state
         state = self.ionic_liquid.simulation.context.getState(getEnergy=True)
@@ -142,16 +160,16 @@ class NaiveMCUpdate(Update):
             for force_to_be_updated in self.allowed_forces:
                 self.ionic_liquid.update_context(force_to_be_updated)
 
-
             # reorient equivalent atoms if needed
 
             if candidate1_residue.used_equivalent_atom:
-                candidate1_residue.used_equivalent_atom = False # reset for next update round
+                candidate1_residue.used_equivalent_atom = (
+                    False  # reset for next update round
+                )
                 self._reorient_atoms(candidate1_residue, positions)
             if candidate2_residue.used_equivalent_atom:
                 candidate2_residue.used_equivalent_atom = False
                 self._reorient_atoms(candidate2_residue, positions)
-
 
             # get new energy
             state = self.ionic_liquid.simulation.context.getState(getEnergy=True)
@@ -167,8 +185,10 @@ class NaiveMCUpdate(Update):
             # also update has_equivalent_atom
             for candidate_residue in (candidate1_residue, candidate2_residue):
                 if candidate_residue.current_name in ("MEOH2", "MEOH", "HOAC", "OAC"):
-                    candidate_residue.has_equivalent_atom = not candidate_residue.has_equivalent_atom
-            
+                    candidate_residue.has_equivalent_atom = (
+                        not candidate_residue.has_equivalent_atom
+                    )
+
             # after the update is finished the current_name attribute is updated (and since alternative_name depends on current_name it too is updated)
             candidate1_residue.current_name = candidate1_residue.alternativ_name
             candidate2_residue.current_name = candidate2_residue.alternativ_name
@@ -176,15 +196,15 @@ class NaiveMCUpdate(Update):
             assert candidate1_residue.current_name != candidate1_residue.alternativ_name
             assert candidate2_residue.current_name != candidate2_residue.alternativ_name
 
-    
         # acceptor current name refers now to a donor -> atom name is the H that can be given on -> this used to be the dummy H
-        idx_accepted_H = acceptor.get_idx_for_atom_name(self.ionic_liquid.templates.get_atom_name_for(acceptor.current_name))
+        idx_accepted_H = acceptor.get_idx_for_atom_name(
+            self.ionic_liquid.templates.get_atom_name_for(acceptor.current_name)
+        )
 
         # update position of the once-dummy H to that of the donated H
         positions[idx_accepted_H] = pos_donated_H
         self.ionic_liquid.simulation.context.setPositions(positions)
         # NOTE: should this happen after the simulation step(s) within the update?
-
 
         # get new energy
         state = self.ionic_liquid.simulation.context.getState(getEnergy=True)

--- a/protex/update.py
+++ b/protex/update.py
@@ -97,9 +97,8 @@ class NaiveMCUpdate(Update):
         donors = []  # determine which candidate was the H-donor / acceptor
         acceptors = []
         pos_donated_Hs = []  # collect the positions of the real Hs at transfer
-        pos_accepted_Hs = (
-            []
-        )  # can't put new H on top of dummy H -> put it a little bit closer to the acceptor
+        pos_accepted_Hs = [] # can't put new H on top of dummy H -> put it a little bit closer to the acceptor
+        pos_acceptor_atoms = []
 
         for candidate in candidates:
             candidate1_residue, candidate2_residue = sorted(
@@ -162,7 +161,8 @@ class NaiveMCUpdate(Update):
                     )
                 ]
 
-            pos_accepted_H = pos_donated_H - 0.99 * (pos_donated_H - pos_acceptor_atom)
+            pos_acceptor_atoms.append(pos_acceptor_atom)
+            pos_accepted_H = pos_donated_H - 0.01 * (pos_donated_H - pos_acceptor_atom)
             pos_accepted_Hs.append(pos_accepted_H)
 
         # get current state
@@ -245,8 +245,9 @@ class NaiveMCUpdate(Update):
 
             # update position of the once-dummy H to that of the donated H (a bit closer to the acceptor to avoid LJ collusion with the now dummy H)
             positions[idx_accepted_H] = pos_accepted_Hs[candidates.index(candidate)]
+            print(f"acceptor: {pos_acceptor_atoms[candidates.index(candidate)]}, donor_H: {pos_donated_Hs[candidates.index(candidate)]}")
             print(
-                f"setting position of {self.ionic_liquid.templates.get_atom_name_for(acceptor.current_name)} of {acceptor.current_name}:{acceptor.residue.index} to {pos_accepted_Hs[candidates.index(candidate)]} from {pos_donated_Hs[candidates.index(candidate)]}"
+                f"setting position of {self.ionic_liquid.templates.get_atom_name_for(acceptor.current_name)} of {acceptor.current_name}:{acceptor.residue.index} to {pos_accepted_Hs[candidates.index(candidate)]}"
             )
 
         self.ionic_liquid.simulation.context.setPositions(positions)

--- a/protex/update.py
+++ b/protex/update.py
@@ -438,4 +438,18 @@ class StateUpdate:
                     residue
                 )  # add second time the residue to have same length of pos_list and res_list
 
+            if residue.current_name == "OAC" and self.updateMethod.meoh2:
+                pos_list.append(
+                    pos[
+                        residue.get_idx_for_atom_name(
+                            self.ionic_liquid.templates.states[residue.current_name][
+                                "other_o"
+                            ]
+                        )
+                    ]
+                )
+                res_list.append(
+                    residue
+                )  # add second time the residue to have same length of pos_list and res_list
+
         return pos_list, res_list

--- a/protex/update.py
+++ b/protex/update.py
@@ -256,8 +256,6 @@ class KeepHUpdate(Update):
 
             donors.append(donor)
             acceptors.append(acceptor)
-            # print(f'{donor.current_name=}, {self.ionic_liquid.templates.has_equivalent_atom(donor.current_name)=}, {acceptor.current_name=}, {self.ionic_liquid.templates.has_equivalent_atom(acceptor.current_name)=}')
-            # print(f'{donor.used_equivalent_atom=}, {acceptor.used_equivalent_atom=}')
 
             if donor.used_equivalent_atom == True:
                 pos_donated_H = positions_copy[
@@ -297,9 +295,6 @@ class KeepHUpdate(Update):
             pos_acceptor_atoms.append(pos_acceptor_atom)
 
             # account for PBC
-            # boxl_vec = (
-            #     self.ionic_liquid.boxlength * pos_donated_H[0] / pos_donated_H[0]._value
-            # )  # very stupid workaround to get a quantity with unit from a number
             boxl_vec = (
                 self.ionic_liquid.boxlength
             )  # changed to store boxl as quantity in system class
@@ -326,61 +321,12 @@ class KeepHUpdate(Update):
                     False  # reset for next update round
                 )
                 self._reorient_atoms(candidate1_residue)
-                # # troubleshooting reorient
-                # atom_idx = candidate1_residue.get_idx_for_atom_name(
-                #     self.ionic_liquid.templates.get_atom_name_for(
-                #         candidate1_residue.current_name
-                #     )
-                # )
-                # equivalent_idx = candidate1_residue.get_idx_for_atom_name(
-                #     self.ionic_liquid.templates.get_equivalent_atom_for(
-                #         candidate1_residue.current_name
-                #     )
-                # )
-
-                # positions = self.ionic_liquid.simulation.context.getState(
-                #     getPositions=True
-                # ).getPositions(asNumpy=False)
-
-                # print(
-                #     f"position of {self.ionic_liquid.templates.get_atom_name_for(candidate1_residue.current_name)} : {positions[atom_idx]} and {self.ionic_liquid.templates.get_equivalent_atom_for(candidate1_residue.current_name)} : {positions[equivalent_idx]}"
-                # )
-                # # troubleshoot end
 
             if candidate2_residue.used_equivalent_atom:
                 candidate2_residue.used_equivalent_atom = False
                 self._reorient_atoms(candidate2_residue)
-                # # troubleshooting reorient
-                # atom_idx = candidate2_residue.get_idx_for_atom_name(
-                #     self.ionic_liquid.templates.get_atom_name_for(
-                #         candidate2_residue.current_name
-                #     )
-                # )
-                # equivalent_idx = candidate2_residue.get_idx_for_atom_name(
-                #     self.ionic_liquid.templates.get_equivalent_atom_for(
-                #         candidate2_residue.current_name
-                #     )
-                # )
 
-                # positions = self.ionic_liquid.simulation.context.getState(
-                #     getPositions=True
-                # ).getPositions(asNumpy=False)
-
-                # print(
-                #     f"position of {self.ionic_liquid.templates.get_atom_name_for(candidate2_residue.current_name)} : {positions[atom_idx]} and {self.ionic_liquid.templates.get_equivalent_atom_for(candidate2_residue.current_name)} : {positions[equivalent_idx]}"
-                # )
-                # # troubleshoot end
-
-            # # also update has_equivalent_atom (not needed if has_equivalent_atom updated via self.ionic_liquid.templates.has_equivalent_atom(residue.current_name))
-            # if candidate1_residue.current_name in ("MEOH2", "MEOH", "HOAC", "OAC"):
-            #     candidate1_residue.has_equivalent_atom = (
-            #         not candidate1_residue.has_equivalent_atom
-            #     )
-
-            # if candidate2_residue.current_name in ("MEOH2", "MEOH", "HOAC", "OAC"):
-            #     candidate2_residue.has_equivalent_atom = (
-            #         not candidate2_residue.has_equivalent_atom
-            #    )
+            # also update has_equivalent_atom (not needed if has_equivalent_atom updated via self.ionic_liquid.templates.has_equivalent_atom(residue.current_name))
 
             #### update refactor orig
             #    self._reorient_atoms(candidate2_residue, positions) #from update refactor orig
@@ -411,14 +357,6 @@ class KeepHUpdate(Update):
 
             # update position of the once-dummy H to that of the donated H (a bit closer to the acceptor to avoid LJ collusion with the now dummy H)
             positions[idx_accepted_H] = pos_accepted_Hs[candidates.index(candidate)]
-            # # troubleshooting
-            # print(
-            #     f"acceptor: {pos_acceptor_atoms[candidates.index(candidate)]}, donor_H: {pos_donated_Hs[candidates.index(candidate)]}"
-            # )
-            # print(
-            #     f"setting position of {self.ionic_liquid.templates.get_atom_name_for(acceptor.current_name)} of {acceptor.current_name}:{acceptor.residue.index} to {pos_accepted_Hs[candidates.index(candidate)]}"
-            # )
-            # # troubleshooting end
 
         self.ionic_liquid.simulation.context.setPositions(positions)
         # NOTE: should this happen directly after the simulation steps if there are multiple steps within the update?
@@ -428,10 +366,6 @@ class KeepHUpdate(Update):
         state = self.ionic_liquid.simulation.context.getState(getEnergy=True)
         new_e = state.getPotentialEnergy()
         logger.info(f"Energy before/after state change:{initial_e}/{new_e}")
-
-        # self.ionic_liquid.simulation.context.setVelocitiesToTemperature(
-        #    300.0 * unit.kelvin
-        # )
 
 
 class NaiveMCUpdate(Update):

--- a/protex/update.py
+++ b/protex/update.py
@@ -21,7 +21,11 @@ class Update:
         Needs the IonicLiquidSystem
     """
 
-    def __init__(self, ionic_liquid: ProtexSystem, to_adapt=None,) -> None:
+    def __init__(
+        self,
+        ionic_liquid: ProtexSystem,
+        to_adapt=None,
+    ) -> None:
         self.ionic_liquid: ProtexSystem = ionic_liquid
         self.to_adapt: list[tuple[str, int, frozenset[str]]] = to_adapt
 

--- a/protex/update.py
+++ b/protex/update.py
@@ -373,8 +373,8 @@ class KeepHUpdate(Update):
             #     candidate2_residue.has_equivalent_atom = (
             #         not candidate2_residue.has_equivalent_atom
             #    )
-            
-            #### update refactor orig 
+
+            #### update refactor orig
             #    self._reorient_atoms(candidate2_residue, positions) #from update refactor orig
 
             # also update has_equivalent_atom
@@ -385,7 +385,7 @@ class KeepHUpdate(Update):
             #        candidate_residue.has_equivalent_atom = (
             #            not candidate_residue.has_equivalent_atom
             #        )
-            
+
             #### update refactor ende
 
             # after the update is finished the current_name attribute is updated (and since alternative_name depends on current_name it too is updated)
@@ -762,7 +762,9 @@ class StateUpdate:
 
             if (
                 self.updateMethod.include_equivalent_atom
-                and self.ionic_liquid.templates.has_equivalent_atom(residue.current_name)
+                and self.ionic_liquid.templates.has_equivalent_atom(
+                    residue.current_name
+                )
             ):
                 pos_list.append(
                     pos[

--- a/protex/update.py
+++ b/protex/update.py
@@ -90,9 +90,9 @@ class NaiveMCUpdate(Update):
         positions[equivalent_idx] = pos_atom
 
         self.ionic_liquid.simulation.context.setPositions(positions)
-        print(
-            f"setting position of {self.ionic_liquid.templates.get_atom_name_for(candidate.current_name)} to {positions[atom_idx]} and {self.ionic_liquid.templates.get_equivalent_atom_for(candidate.current_name)} to {positions[equivalent_idx]}"
-        )
+        # print(
+        #     f"setting position of {self.ionic_liquid.templates.get_atom_name_for(candidate.current_name)} to {positions[atom_idx]} and {self.ionic_liquid.templates.get_equivalent_atom_for(candidate.current_name)} to {positions[equivalent_idx]}"
+        # )
 
     def _update(self, candidates: list[tuple], nr_of_steps: int):
         logger.info("called _update")
@@ -178,8 +178,8 @@ class NaiveMCUpdate(Update):
 
             donors.append(donor)
             acceptors.append(acceptor)
-            print(f'{donor.current_name=}, {self.ionic_liquid.templates.has_equivalent_atom(donor.current_name)=}, {acceptor.current_name=}, {self.ionic_liquid.templates.has_equivalent_atom(acceptor.current_name)=}')
-            print(f'{donor.used_equivalent_atom=}, {acceptor.used_equivalent_atom=}')
+            # print(f'{donor.current_name=}, {self.ionic_liquid.templates.has_equivalent_atom(donor.current_name)=}, {acceptor.current_name=}, {self.ionic_liquid.templates.has_equivalent_atom(acceptor.current_name)=}')
+            # print(f'{donor.used_equivalent_atom=}, {acceptor.used_equivalent_atom=}')
 
             if donor.used_equivalent_atom == True:
                 pos_donated_H = positions_copy[

--- a/protex/update.py
+++ b/protex/update.py
@@ -163,7 +163,10 @@ class NaiveMCUpdate(Update):
             if "H" in self.ionic_liquid.templates.get_atom_name_for(
                 candidate1_residue.current_name
             ) or (
-                self.ionic_liquid.templates.has_equivalent_atom(candidate1_residue.current_name) == True
+                self.ionic_liquid.templates.has_equivalent_atom(
+                    candidate1_residue.current_name
+                )
+                == True
                 and "H"
                 in self.ionic_liquid.templates.get_equivalent_atom_for(
                     candidate1_residue.current_name
@@ -178,8 +181,10 @@ class NaiveMCUpdate(Update):
 
             donors.append(donor)
             acceptors.append(acceptor)
-            print(f'{donor.current_name=}, {self.ionic_liquid.templates.has_equivalent_atom(donor.current_name)=}, {acceptor.current_name=}, {self.ionic_liquid.templates.has_equivalent_atom(acceptor.current_name)=}')
-            print(f'{donor.used_equivalent_atom=}, {acceptor.used_equivalent_atom=}')
+            print(
+                f"{donor.current_name=}, {self.ionic_liquid.templates.has_equivalent_atom(donor.current_name)=}, {acceptor.current_name=}, {self.ionic_liquid.templates.has_equivalent_atom(acceptor.current_name)=}"
+            )
+            print(f"{donor.used_equivalent_atom=}, {acceptor.used_equivalent_atom=}")
 
             if donor.used_equivalent_atom == True:
                 pos_donated_H = positions_copy[
@@ -655,7 +660,7 @@ class StateUpdate:
                 residue.equivalent_atom_pos_in_list = len(
                     res_list
                 )  # store idx to know which coordinates where used for distance
-                
+
                 res_list.append(
                     residue
                 )  # add second time the residue to have same length of pos_list and res_list

--- a/protex/update.py
+++ b/protex/update.py
@@ -120,15 +120,18 @@ class KeepHUpdate(Update):
     KeepHUpdate performs updates but uses the original H position
     keep the position of the original H when switching from dummy to real H
     """
+
     def __init__(
         self,
         ionic_liquid: ProtexSystem,
         all_forces: bool = False,
         to_adapt: list[tuple[str, int, frozenset[str]]] = None,
-        include_equivalent_atom: bool = False, 
+        include_equivalent_atom: bool = False,
         reorient: bool = False,
     ) -> None:
-        super().__init__(ionic_liquid, to_adapt, all_forces, include_equivalent_atom, reorient)
+        super().__init__(
+            ionic_liquid, to_adapt, all_forces, include_equivalent_atom, reorient
+        )
 
     def _reorient_atoms(self, candidate, positions):
         # Function to reorient atoms if the equivalent atom was used for shortest distance
@@ -290,8 +293,9 @@ class KeepHUpdate(Update):
                 self._reorient_atoms(candidate2_residue, positions)
 
             # also update has_equivalent_atom
-            #TODO: adapt somehow in residue class, need information if current name or alternativ name have equivalent atom and adjust accordingly to current name!
-            #for candidate_residue in (candidate1_residue, candidate2_residue):
+            # TODO: adapt somehow in residue class, need information if current name or alternativ name have equivalent atom and adjust accordingly to current name! ->
+            # residue.has_equivalent_atom now give the information depending on the current name.
+            # for candidate_residue in (candidate1_residue, candidate2_residue):
             #    if candidate_residue.current_name in ("MEOH2", "MEOH", "HOAC", "OAC"):
             #        candidate_residue.has_equivalent_atom = (
             #            not candidate_residue.has_equivalent_atom
@@ -329,6 +333,7 @@ class KeepHUpdate(Update):
         #    300.0 * unit.kelvin
         # )
 
+
 class NaiveMCUpdate(Update):
     """
     NaiveMCUpdate Performs naive MC update on molecule pairs in close proximity
@@ -345,11 +350,15 @@ class NaiveMCUpdate(Update):
         all_forces: bool = False,
         to_adapt: list[tuple[str, int, frozenset[str]]] = None,
         include_equivalent_atom: bool = False,
-        reorient: bool = False
+        reorient: bool = False,
     ) -> None:
-        super().__init__(ionic_liquid, to_adapt, all_forces, include_equivalent_atom, reorient)
+        super().__init__(
+            ionic_liquid, to_adapt, all_forces, include_equivalent_atom, reorient
+        )
         if reorient:
-            raise NotImplementedError("Currently reorienting atoms if equivalent atoms are used is not implemented. Set reorient=False.")
+            raise NotImplementedError(
+                "Currently reorienting atoms if equivalent atoms are used is not implemented. Set reorient=False."
+            )
 
     def _update(self, candidates: list[tuple], nr_of_steps: int) -> None:
         logger.info("called _update")
@@ -414,6 +423,7 @@ class NaiveMCUpdate(Update):
         # self.ionic_liquid.simulation.context.setVelocitiesToTemperature(
         #    300.0 * unit.kelvin
         # )
+
 
 class StateUpdate:
     """
@@ -657,7 +667,10 @@ class StateUpdate:
             )
             res_list.append(residue)
 
-            if self.updateMethod.include_equivalent_atom and residue.has_equivalent_atom:
+            if (
+                self.updateMethod.include_equivalent_atom
+                and residue.has_equivalent_atom
+            ):
                 pos_list.append(
                     pos[
                         residue.get_idx_for_atom_name(

--- a/protex/update.py
+++ b/protex/update.py
@@ -97,7 +97,9 @@ class NaiveMCUpdate(Update):
         donors = []  # determine which candidate was the H-donor / acceptor
         acceptors = []
         pos_donated_Hs = []  # collect the positions of the real Hs at transfer
-        pos_accepted_Hs = [] # can't put new H on top of dummy H -> put it a little bit closer to the acceptor
+        pos_accepted_Hs = (
+            []
+        )  # can't put new H on top of dummy H -> put it a little bit closer to the acceptor
         pos_acceptor_atoms = []
 
         for candidate in candidates:
@@ -245,7 +247,9 @@ class NaiveMCUpdate(Update):
 
             # update position of the once-dummy H to that of the donated H (a bit closer to the acceptor to avoid LJ collusion with the now dummy H)
             positions[idx_accepted_H] = pos_accepted_Hs[candidates.index(candidate)]
-            print(f"acceptor: {pos_acceptor_atoms[candidates.index(candidate)]}, donor_H: {pos_donated_Hs[candidates.index(candidate)]}")
+            print(
+                f"acceptor: {pos_acceptor_atoms[candidates.index(candidate)]}, donor_H: {pos_donated_Hs[candidates.index(candidate)]}"
+            )
             print(
                 f"setting position of {self.ionic_liquid.templates.get_atom_name_for(acceptor.current_name)} of {acceptor.current_name}:{acceptor.residue.index} to {pos_accepted_Hs[candidates.index(candidate)]}"
             )

--- a/protex/update.py
+++ b/protex/update.py
@@ -1,7 +1,7 @@
+import copy
 import logging
 import random
 from collections import Counter
-import copy
 
 import numpy as np
 from scipy.spatial import distance_matrix


### PR DESCRIPTION
## Description
Attempt to refactor and better structure the update.py file and its classes.
Made Update() an Abstract Base Class, with the abstractmethod _update.
Each concrete implementation has to at least implement this method.
Added an additional implementation besides NaiveMCUpdate, which uses the new transfer idea proposed in PR #55 and #56.
Tried to structure the two new ideas:
- new transfer idea -> new class
- additional consideration of equivalent atom (#55) and possibly adapting the orientation of the molecules -> new keywords for each class.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Make Update ABC
  - [x] new class for new proton transfer method
  - [x] additional keyword for equivalent atoms...
  - [x] ...and implementation
  - [x] additional keyword for reorientation ...
  - [x] ..and implementaiton
  - [ ] testing

## Things to consider
- [ ] Think about quering state.getPositions ideally only once
- [ ] Think about the structure of the new transfer class
- [ ] Find a useful name for this class (any ideas @godenymarta?)

## Status
- [ ] Ready to go