### PR TITLE
make a deque(maxlen=10) from history

### DIFF
--- a/protex/update.py
+++ b/protex/update.py
@@ -603,7 +603,9 @@ class StateUpdate:
         # print(f"{idx=}")
 
         proposed_candidate_pairs = []
-        proposed_candidate_pair_sets = [] # didn't want to make sets from proposed_candidate_pairs altogether, second list for basically same information may be superfluous
+        proposed_candidate_pair_sets = (
+            []
+        )  # didn't want to make sets from proposed_candidate_pairs altogether, second list for basically same information may be superfluous
         used_residues = []
         # check if charge transfer is possible
         for candidate_idx1, candidate_idx2 in idx:
@@ -646,7 +648,10 @@ class StateUpdate:
                         )
                         continue
                     # reject if already in last 10 updates
-                    if any(set(proposed_candidate_pair) in sublist for sublist in self.history):
+                    if any(
+                        set(proposed_candidate_pair) in sublist
+                        for sublist in self.history
+                    ):
                         logger.debug(
                             f"{residue1.current_name}:{residue1.residue.id}:{charge_candidate_idx1}-{residue2.current_name}:{residue2.residue.id}:{charge_candidate_idx2} pair rejected, bc in history ..."
                         )

--- a/protex/update.py
+++ b/protex/update.py
@@ -467,7 +467,7 @@ class StateUpdate:
     def __init__(self, updateMethod: Update) -> None:
         self.updateMethod: Update = updateMethod
         self.ionic_liquid: ProtexSystem = self.updateMethod.ionic_liquid
-        self.history: deque(maxlen=10)
+        self.history: deque = deque(maxlen=10)
         self.update_trial: int = 0
 
     def write_charges(self, filename: str) -> None:


### PR DESCRIPTION
append list of candidate_pairs
append empty list if no eligible candidate pairs

## Description
History should only block UpdatePairs for 10 updates -> need to add an empty element if there are no successful updates.
Use a deque instead of a list, so that it is automatically updated with time.

## Todos
Notable points that this PR has either accomplished or will accomplish.
- [ ]  update code
- [ ] testing

## Status
- [ ] Ready to go